### PR TITLE
WebComponents support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /build
+/dist
 /.svelte-kit
 /package
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "^8.33.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-svelte3": "^4.0.0",
+        "fast-glob": "^3.2.12",
         "prettier": "^2.8.3",
         "prettier-plugin-svelte": "^2.9.0",
         "svelte-check": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-svelte3": "^4.0.0",
+    "fast-glob": "^3.2.12",
     "prettier": "^2.8.3",
     "prettier-plugin-svelte": "^2.9.0",
     "svelte-check": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
+  "exports": {
+    "./**/*.js": "./**/*.js"
+  },
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.5",
     "@sveltejs/kit": "^1.3.9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.3.0",
   "scripts": {
     "dev": "vite dev",
-    "build": "svelte-kit sync && svelte-package",
+    "build": "npm run build:svelte && npm run build:web",
+    "build:svelte": "svelte-kit sync && svelte-package",
+    "build:web": "vite build -c vite.config.lib.js && cp -r dist/* package/ && rm -r dist",
     "prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?' && exit 1",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
     "format": "prettier --plugin-search-dir . --write .",

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -1,0 +1,33 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { resolve } from "node:path";
+import glob from "fast-glob";
+
+const entries = Object.fromEntries(
+  glob
+    .sync("./src/lib/**/*.svelte", {
+      ignore: ["./src/lib/**/_*.svelte", "./src/lib/**/_**/*.svelte"],
+    })
+    .map((entry) => [entry.slice(10).slice(0, -7), entry])
+);
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: entries,
+      formats: ["es"],
+    },
+  },
+  plugins: [
+    svelte({
+      compilerOptions: {
+        customElement: true,
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      $lib: resolve(__dirname, "src/lib"),
+    },
+  },
+});


### PR DESCRIPTION
This PR exports WebComponents via the customElement option in `vite-plugin-svelte`.

PS: Due to the use of `cp` and `rm` in the script, it is not compatible with Windows

TODO:

- Set the svelte:options tag for each component (prefix to be determined)