### PR TITLE
set vite `outDir` instead of mv

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "package": "svelte-kit sync && svelte-package",
-    "package-components": "vite build -c vite.config.lib.js && mv dist package-components",
+    "package-components": "vite build -c vite.config.lib.js",
     "prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?' && exit 1",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
     "format": "prettier --plugin-search-dir . --write .",

--- a/vite.config.lib.js
+++ b/vite.config.lib.js
@@ -13,6 +13,7 @@ const entries = Object.fromEntries(
 
 export default defineConfig({
   build: {
+    outDir: "package-components",
     lib: {
       entry: entries,
       formats: ["es"],


### PR DESCRIPTION
but since `package-components` is no longer included in the `package` directory, it may need to be packaged differently... up to you.

remove exports in `package.json`:

```diff
  },
- "exports": {
-   "./**/*.js": "./**/*.js"
- },
  "devDependencies": {
```