### PR TITLE
Outlined TextField's label has a different background color

### DIFF
--- a/src/lib/forms/TextField.svelte
+++ b/src/lib/forms/TextField.svelte
@@ -72,11 +72,7 @@
     top: 1rem;
     color: rgb(var(--error, var(--m3-scheme-on-surface-variant)));
     pointer-events: none;
-    transition:
-      all 200ms,
-      font-size 300ms,
-      line-height 300ms,
-      letter-spacing 300ms;
+    transition: all 200ms, font-size 300ms, line-height 300ms, letter-spacing 300ms;
   }
   .layer {
     position: absolute;
@@ -91,10 +87,11 @@
     display: block;
     width: 100%;
     bottom: 0;
-
     height: 0.0625rem;
     background-color: rgb(var(--error, var(--m3-scheme-on-surface-variant)));
-    transition: all 200ms;
+    transition: all 250ms;
+    transform: scaleX(0);
+    transform-origin: center;
   }
   .m3-container :global(svg) {
     width: 1.5rem;
@@ -145,6 +142,7 @@
   input:focus ~ .layer::after {
     height: 0.125rem;
     background-color: rgb(var(--error, var(--m3-scheme-primary)));
+    transform: scaleX(1);
   }
   @media (hover: hover) {
     button:hover {

--- a/src/lib/forms/TextFieldOutlined.svelte
+++ b/src/lib/forms/TextFieldOutlined.svelte
@@ -17,6 +17,21 @@
   export let value = "";
   const dispatch = createEventDispatcher();
   const id = crypto.randomUUID();
+
+  // find the nearest ancestor which has background color
+  function findNearestBackgroundColor(node: HTMLElement | null): string {
+    if (!node) {
+      return "rgb(var(--m3-util-background, var(--m3-scheme-surface)))";
+    }
+    const backgroundColor = window.getComputedStyle(node).backgroundColor;
+    if (backgroundColor === "rgba(0, 0, 0, 0)" || backgroundColor === "transparent") {
+      return findNearestBackgroundColor(node.parentElement);
+    }
+    return backgroundColor;
+  }
+
+  let labelElement: HTMLLabelElement;
+  $: labelBackgroundColor = findNearestBackgroundColor(labelElement?.parentElement);
 </script>
 
 <div
@@ -37,7 +52,12 @@
     {...extraOptions}
   />
   <div class="layer" />
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label
+    class="m3-font-body-large"
+    for={id}
+    bind:this={labelElement}
+    style={`background-color: ${labelBackgroundColor}`}>{name}</label
+  >
   {#if leadingIcon}
     <Icon icon={leadingIcon} class="leading" />
   {/if}
@@ -72,14 +92,9 @@
     left: 0.75rem;
     top: 1rem;
     color: rgb(var(--error, var(--m3-scheme-on-surface-variant)));
-    background-color: rgb(var(--m3-util-background, var(--m3-scheme-surface)));
     padding: 0 0.25rem;
     pointer-events: none;
-    transition:
-      all 200ms,
-      font-size 300ms,
-      line-height 300ms,
-      letter-spacing 300ms;
+    transition: all 200ms, font-size 300ms, line-height 300ms, letter-spacing 300ms;
   }
   .layer {
     position: absolute;

--- a/src/lib/forms/TextFieldOutlinedMultiline.svelte
+++ b/src/lib/forms/TextFieldOutlinedMultiline.svelte
@@ -28,6 +28,21 @@
       },
     };
   };
+
+  // find the nearest ancestor which has background color
+  function findNearestBackgroundColor(node: HTMLElement | null): string {
+    if (!node) {
+      return "rgb(var(--m3-util-background, var(--m3-scheme-surface)))";
+    }
+    const backgroundColor = window.getComputedStyle(node).backgroundColor;
+    if (backgroundColor === "rgba(0, 0, 0, 0)" || backgroundColor === "transparent") {
+      return findNearestBackgroundColor(node.parentElement);
+    }
+    return backgroundColor;
+  }
+
+  let labelElement: HTMLLabelElement;
+  $: labelBackgroundColor = findNearestBackgroundColor(labelElement?.parentElement);
 </script>
 
 <div
@@ -48,7 +63,12 @@
     {...extraOptions}
   />
   <div class="layer" />
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label
+    class="m3-font-body-large"
+    for={id}
+    bind:this={labelElement}
+    style={`background-color: ${labelBackgroundColor}`}>{name}</label
+  >
   {#if leadingIcon}
     <Icon icon={leadingIcon} />
   {/if}
@@ -79,14 +99,9 @@
     left: 0.75rem;
     top: 1rem;
     color: rgb(var(--error, var(--m3-scheme-on-surface-variant)));
-    background-color: rgb(var(--m3-util-background, var(--m3-scheme-surface)));
     padding: 0 0.25rem;
     pointer-events: none;
-    transition:
-      all 200ms,
-      font-size 300ms,
-      line-height 300ms,
-      letter-spacing 300ms;
+    transition: all 200ms, font-size 300ms, line-height 300ms, letter-spacing 300ms;
   }
   .layer {
     position: absolute;


### PR DESCRIPTION
First of all, thank you for this great library.

If you use `TextFieldOutlined` in a parent that does not have `scheme-surface` as its background color, the label's background color is different and it stands out. It looks weird. This is a quick fix I came up with. Tested it and it works fine for me. Let me know what you think.