### PR TITLE
docs: add `extraOptions` to `TextField`

### DIFF
--- a/src/routes/TextFieldCard.svelte
+++ b/src/routes/TextFieldCard.svelte
@@ -7,19 +7,15 @@
   import TextFieldOutlinedMultiline from "$lib/forms/TextFieldOutlinedMultiline.svelte";
   import Card from "./_card.svelte";
   import Arrows from "./Arrows.svelte";
+  import type {HTMLInputAttributes, HTMLTextareaAttributes} from "svelte/elements";
 
+  let extraOptions: HTMLInputAttributes = {};
   let type = "filled";
   let leadingIcon = false;
   let errored = false;
   let enabled = true;
-  $: component =
-    type == "filled"
-      ? TextField
-      : type == "filled_multiline"
-        ? TextFieldMultiline
-        : type == "outlined"
-          ? TextFieldOutlined
-          : TextFieldOutlinedMultiline;
+  let option = "text";
+  $: extraOptions.type = option;
 </script>
 
 <Card>
@@ -44,6 +40,23 @@
     </tr>
     <tr>
       <td>
+        <Arrows
+          list={["text", "password", "number", "file"]}
+          bind:value={option}
+        />
+      </td>
+      <td>
+        {option == "text"
+          ? "Text"
+          : option == "password"
+            ? "Password"
+            : option == "number"
+              ? "Number"
+              : "File"}
+      </td>
+    </tr>
+    <tr>
+      <td>
         <label for={undefined}><Switch bind:checked={leadingIcon} /></label>
       </td>
       <td>{leadingIcon ? "Leading icon" : "No leading icon"}</td>
@@ -62,14 +75,41 @@
     </tr>
   </table>
   <div class="area" slot="demo">
-    <svelte:component
-      this={component}
-      name="Field"
-      leadingIcon={leadingIcon ? iconEdit : undefined}
-      error={errored}
-      disabled={!enabled}
-      --m3-util-background="var(--m3-scheme-surface-container-low)"
-    />
+    {#if type === "filled"}
+      <TextField
+        name="Field"
+        leadingIcon={leadingIcon ? iconEdit : undefined}
+        error={errored}
+        disabled={!enabled}
+        extraOptions={extraOptions}
+        --m3-util-background="var(--m3-scheme-surface-container-low)"
+      />
+    {:else if type === "outlined"}
+      <TextFieldOutlined
+        name="Field"
+        leadingIcon={leadingIcon ? iconEdit : undefined}
+        error={errored}
+        disabled={!enabled}
+        extraOptions={extraOptions}
+        --m3-util-background="var(--m3-scheme-surface-container-low)"
+      />
+    {:else if type === "filled_multiline"}
+      <TextFieldMultiline
+        name="Field"
+        leadingIcon={leadingIcon ? iconEdit : undefined}
+        error={errored}
+        disabled={!enabled}
+        --m3-util-background="var(--m3-scheme-surface-container-low)"
+      />
+    {:else if type === "outlined_multiline"}
+      <TextFieldOutlinedMultiline
+        name="Field"
+        leadingIcon={leadingIcon ? iconEdit : undefined}
+        error={errored}
+        disabled={!enabled}
+        --m3-util-background="var(--m3-scheme-surface-container-low)"
+      />
+    {/if}
   </div>
 </Card>
 


### PR DESCRIPTION
Hey!

Thanks for this awesome library. I'm soon planning to replace SMUI with it. It'd be very nice if at least one of the examples contained the feature of `extraOptions`.

Sorry for not following the code style and avoiding all TypeScript (colossal brain damage) due to infinite errors whilst mixing `HTMLInputAttributes` and `HTMLTextFieldAttributes`. In hindsight, it'd likely have been better to make separate `Card`s for `TextFieldMultiline` and `TextField`, but oh well.

I can probably do it myself in order not to put even more burden on you, but I need help in figuring out, what'd be the best option to implement this.

Thanks