### PR TITLE
feat: add ripple effect

### DIFF
--- a/src/lib/buttons/Button.svelte
+++ b/src/lib/buttons/Button.svelte
@@ -1,19 +1,23 @@
 <script lang="ts">
+  import Ripple from "$lib/effects/Ripple.svelte";
   import type { HTMLButtonAttributes } from "svelte/elements";
   export let display = "inline-flex";
   export let extraOptions: HTMLButtonAttributes = {};
   export let iconType: "none" | "left" | "full" = "none";
   export let type: "elevated" | "filled" | "tonal" | "outlined" | "text";
   export let disabled = false;
+  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
   on:click|stopPropagation
+  on:mousedown={ripple}
   {disabled}
   class="m3-container m3-font-label-large {type} icon-{iconType}"
   style="display: {display};"
   {...extraOptions}
 >
+  <Ripple bind:ripple color="secondary" />
   <div class="layer" />
   <slot />
 </button>

--- a/src/lib/buttons/Button.svelte
+++ b/src/lib/buttons/Button.svelte
@@ -6,18 +6,16 @@
   export let iconType: "none" | "left" | "full" = "none";
   export let type: "elevated" | "filled" | "tonal" | "outlined" | "text";
   export let disabled = false;
-  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
   on:click|stopPropagation
-  on:mousedown={ripple}
   {disabled}
   class="m3-container m3-font-label-large {type} icon-{iconType}"
   style="display: {display};"
   {...extraOptions}
 >
-  <Ripple bind:ripple color="secondary" />
+  <Ripple color="secondary" />
   <div class="layer" />
   <slot />
 </button>

--- a/src/lib/buttons/FAB.svelte
+++ b/src/lib/buttons/FAB.svelte
@@ -7,7 +7,7 @@
 
   export let display = "inline-flex";
   export let extraOptions: HTMLButtonAttributes = {};
-  const color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
+  export let color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
   export let size: "small" | "normal" | "large" = "normal";
   export let elevation: "normal" | "lowered" | "none" = "normal";
   export let icon: IconifyIcon | undefined = undefined;

--- a/src/lib/buttons/FAB.svelte
+++ b/src/lib/buttons/FAB.svelte
@@ -13,8 +13,6 @@
   export let icon: IconifyIcon | undefined = undefined;
   export let text: string | undefined = undefined;
 
-  let ripple: (e: MouseEvent) => Promise<void>;
-
   $: {
     if (!icon && !text) console.warn("you need at least something in a FAB");
     if (size != "normal" && text) console.warn("extended fabs are supposed to use size normal");
@@ -23,12 +21,11 @@
 
 <button
   on:click
-  on:mousedown={ripple}
   class="m3-container m3-font-label-large color-{color} size-{size} elevation-{elevation}"
   style="display: {display};"
   {...extraOptions}
 >
-  <Ripple bind:ripple color="secondary" />
+  <Ripple color="secondary" />
   <div class="layer" />
   {#if icon}
     <Icon {icon} />

--- a/src/lib/buttons/FAB.svelte
+++ b/src/lib/buttons/FAB.svelte
@@ -2,14 +2,19 @@
   import type { HTMLButtonAttributes } from "svelte/elements";
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
+  import { createEventDispatcher } from "svelte";
+  import Ripple from "$lib/effects/Ripple.svelte";
 
   export let display = "inline-flex";
   export let extraOptions: HTMLButtonAttributes = {};
-  export let color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
+  const color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
   export let size: "small" | "normal" | "large" = "normal";
   export let elevation: "normal" | "lowered" | "none" = "normal";
   export let icon: IconifyIcon | undefined = undefined;
   export let text: string | undefined = undefined;
+
+  let ripple: (e: MouseEvent) => Promise<void>;
+
   $: {
     if (!icon && !text) console.warn("you need at least something in a FAB");
     if (size != "normal" && text) console.warn("extended fabs are supposed to use size normal");
@@ -18,10 +23,12 @@
 
 <button
   on:click
+  on:mousedown={ripple}
   class="m3-container m3-font-label-large color-{color} size-{size} elevation-{elevation}"
   style="display: {display};"
   {...extraOptions}
 >
+  <Ripple bind:ripple color="secondary" />
   <div class="layer" />
   {#if icon}
     <Icon {icon} />

--- a/src/lib/buttons/SegmentedButtonItem.svelte
+++ b/src/lib/buttons/SegmentedButtonItem.svelte
@@ -9,14 +9,6 @@
   export let extraOptions: HTMLLabelAttributes = {};
   export let input: string;
   export let icon: IconifyIcon | undefined = undefined;
-
-  let ripple: (e: MouseEvent) => Promise<void>;
-
-  const tsRipple = (e: MouseEvent) => {
-    const el = document.getElementById(input) as HTMLInputElement;
-    if (el.disabled) return;
-    ripple(e);
-  };
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
@@ -26,9 +18,8 @@
   class="m3-font-label-large"
   style="display: {display}; overflow: hidden;"
   {...extraOptions}
-  on:mousedown={tsRipple}
 >
-  <Ripple color="secondary" bind:ripple />
+  <Ripple color="secondary" />
   <div class="layer" />
   <div class="pad" />
   {#if icon}

--- a/src/lib/buttons/SegmentedButtonItem.svelte
+++ b/src/lib/buttons/SegmentedButtonItem.svelte
@@ -4,11 +4,32 @@
   import type { IconifyIcon } from "@iconify/types";
   import iconCheck from "@ktibow/iconset-material-symbols/check";
   import Ripple from "$lib/effects/Ripple.svelte";
+  import { onMount } from "svelte";
 
   export let display = "flex";
   export let extraOptions: HTMLLabelAttributes = {};
   export let input: string;
   export let icon: IconifyIcon | undefined = undefined;
+  let disabled = false;
+
+  onMount(() => {
+    const inputEl = document.getElementById(input) as HTMLInputElement;
+    if (!inputEl) return;
+    disabled = inputEl.disabled;
+    var observer = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        // Check the modified attributeName is "disabled"
+        if (mutation.attributeName === "disabled") {
+          alert("disabled changed");
+        }
+      });
+    });
+    var config = { attributes: true };
+    observer.observe(inputEl, config);
+    return () => {
+      observer.disconnect();
+    };
+  });
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
@@ -19,7 +40,9 @@
   style="display: {display}; overflow: hidden;"
   {...extraOptions}
 >
-  <Ripple color="secondary" />
+  {#if !disabled}
+    <Ripple color="secondary" />
+  {/if}
   <div class="layer" />
   <div class="pad" />
   {#if icon}

--- a/src/lib/buttons/SegmentedButtonItem.svelte
+++ b/src/lib/buttons/SegmentedButtonItem.svelte
@@ -3,20 +3,32 @@
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
   import iconCheck from "@ktibow/iconset-material-symbols/check";
+  import Ripple from "$lib/effects/Ripple.svelte";
 
   export let display = "flex";
   export let extraOptions: HTMLLabelAttributes = {};
   export let input: string;
   export let icon: IconifyIcon | undefined = undefined;
+
+  let ripple: (e: MouseEvent) => Promise<void>;
+
+  const tsRipple = (e: MouseEvent) => {
+    const el = document.getElementById(input) as HTMLInputElement;
+    if (el.disabled) return;
+    ripple(e);
+  };
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <label
   class:custom-icon={icon}
   for={input}
   class="m3-font-label-large"
-  style="display: {display};"
+  style="display: {display}; overflow: hidden;"
   {...extraOptions}
+  on:mousedown={tsRipple}
 >
+  <Ripple color="secondary" bind:ripple />
   <div class="layer" />
   <div class="pad" />
   {#if icon}

--- a/src/lib/containers/CardClickable.svelte
+++ b/src/lib/containers/CardClickable.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
+  import Ripple from "$lib/effects/Ripple.svelte";
   import type { HTMLAttributes, HTMLButtonAttributes } from "svelte/elements";
 
   export let display = "flex";
   export let extraOptions: HTMLAttributes<HTMLDivElement> & HTMLButtonAttributes = {};
   export let type: "elevated" | "filled" | "outlined";
+  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
   on:click|stopPropagation
   class="m3-container type-{type}"
-  style="display: {display};"
+  style="display: {display}; overflow: hidden;"
   {...extraOptions}
+  on:mousedown={ripple}
 >
+  <Ripple bind:ripple color="secondary" />
   <div class="layer" />
   <slot />
 </button>

--- a/src/lib/containers/CardClickable.svelte
+++ b/src/lib/containers/CardClickable.svelte
@@ -5,7 +5,6 @@
   export let display = "flex";
   export let extraOptions: HTMLAttributes<HTMLDivElement> & HTMLButtonAttributes = {};
   export let type: "elevated" | "filled" | "outlined";
-  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
@@ -13,9 +12,8 @@
   class="m3-container type-{type}"
   style="display: {display}; overflow: hidden;"
   {...extraOptions}
-  on:mousedown={ripple}
 >
-  <Ripple bind:ripple color="secondary" />
+  <Ripple color="secondary" />
   <div class="layer" />
   <slot />
 </button>

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -38,7 +38,7 @@
     }
   }}
   bind:this={dialog}
-  style="display: {display};"
+  style="display: {display}; z-index: 9999;"
   {...extraOptions}
 >
   <div class="m3-container">

--- a/src/lib/containers/MenuItem.svelte
+++ b/src/lib/containers/MenuItem.svelte
@@ -5,11 +5,10 @@
 
   export let icon: IconifyIcon | "space" | undefined = undefined;
   export let disabled = false;
-  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
-<button on:mousedown={ripple} class="item m3-font-label-large" {disabled} on:click>
-  <Ripple color="secondary" bind:ripple />
+<button class="item m3-font-label-large" {disabled} on:click>
+  <Ripple color="secondary" />
   {#if icon == "space"}
     <span class="icon" />
   {:else if icon}

--- a/src/lib/containers/MenuItem.svelte
+++ b/src/lib/containers/MenuItem.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import Ripple from "$lib/effects/Ripple.svelte";
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
 
   export let icon: IconifyIcon | "space" | undefined = undefined;
   export let disabled = false;
+  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
-<button class="item m3-font-label-large" {disabled} on:click>
+<button on:mousedown={ripple} class="item m3-font-label-large" {disabled} on:click>
+  <Ripple color="secondary" bind:ripple />
   {#if icon == "space"}
     <span class="icon" />
   {:else if icon}
@@ -19,6 +22,8 @@
 
 <style>
   .item {
+    position: relative;
+    overflow: hidden;
     display: flex;
     align-items: center;
     height: 3rem;

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -26,7 +26,26 @@
     svg.style.width = clone.offsetWidth * 2 + "px";
     svg.style.height = clone.offsetHeight * 2 + "px";
     clone.style.transform = `translate(${e.clientX - bounds.left}px, ${e.clientY - bounds.top}px)`;
-    clone.style.opacity = "0.1";
+    clone.style.opacity = "1";
+    const duration = 2000;
+    const apparentDuration = duration / 4;
+    clone.animate(
+      [
+        {
+          opacity: 1,
+        },
+        {
+          opacity: 0,
+        },
+      ],
+      {
+        duration: apparentDuration,
+        easing: "ease-out",
+        fill: "forwards",
+        delay: apparentDuration / 2,
+      },
+    );
+
     svg.animate(
       [
         {
@@ -37,26 +56,9 @@
         },
       ],
       {
-        duration: 750,
-        delay: 250,
+        duration: apparentDuration,
         easing: "ease-out",
         fill: "forwards",
-      },
-    );
-    clone.animate(
-      [
-        {
-          opacity: 0.1,
-        },
-        {
-          opacity: 0,
-        },
-      ],
-      {
-        duration: 500,
-        easing: "ease-in",
-        fill: "forwards",
-        delay: 250,
       },
     );
 
@@ -71,12 +73,12 @@
           height: 0,
         },
         {
-          width: clone.offsetWidth * 2 + "px",
-          height: clone.offsetHeight * 2 + "px",
+          width: clone.offsetWidth * 6 + "px",
+          height: clone.offsetHeight * 6 + "px",
         },
       ],
       {
-        duration: 1250,
+        duration: duration,
         easing: "cubic-bezier(.05,.7,.1,1)",
         fill: "forwards",
       },
@@ -94,7 +96,7 @@
 
 <div class="rippleContainer" bind:this={rippleContainer}>
   <div
-    style="background: radial-gradient(circle, rgb(var(--m3-scheme-on-{color}-container)) 20%, transparent 80%);"
+    style="--col: rgb(var(--m3-scheme-on-{color}-container))"
     bind:this={rippleEl}
     class="ripple color-{color}"
   >
@@ -195,6 +197,11 @@
   }
 
   .ripple {
+    background: radial-gradient(
+      circle,
+      color-mix(in srgb, var(--col), transparent 90%) 20%,
+      transparent 40%
+    );
     border-radius: 50%;
     position: absolute;
     pointer-events: none;
@@ -204,6 +211,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    mask-image: radial-gradient(circle, black 0%, transparent 50%);
+    mask-size: 100% 100%;
   }
 
   .maskable-noise {

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -47,7 +47,7 @@
         },
       ],
       {
-        duration: 750,
+        duration: 500,
         easing: "ease-in",
         fill: "forwards",
         delay: 250,

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -20,22 +20,54 @@
     svg.style.width = clone.offsetWidth * 2 + "px";
     svg.style.height = clone.offsetHeight * 2 + "px";
     clone.style.transform = `translate(${e.clientX - bounds.left}px, ${e.clientY - bounds.top}px)`;
+    clone.style.opacity = "0.1";
+    svg.animate(
+      [
+        {
+          opacity: 0.75,
+        },
+        {
+          opacity: 0,
+        },
+      ],
+      {
+        duration: 750,
+        delay: 250,
+        easing: "ease-out",
+        fill: "forwards",
+      },
+    );
+    clone.animate(
+      [
+        {
+          opacity: 0.1,
+        },
+        {
+          opacity: 0,
+        },
+      ],
+      {
+        duration: 750,
+        easing: "ease-in",
+        fill: "forwards",
+        delay: 250,
+      },
+    );
     await clone.animate(
       [
         {
           width: 0,
           height: 0,
-          opacity: 0.3,
         },
         {
           width: clone.offsetWidth * 2 + "px",
           height: clone.offsetHeight * 2 + "px",
-          opacity: 0,
         },
       ],
       {
         duration: 1250,
         easing: "cubic-bezier(.05,.7,.1,1)",
+        fill: "forwards",
       },
     ).finished;
     clone.remove();

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+
   let rippleEl: HTMLDivElement;
   let rippleContainer: HTMLDivElement;
   export let color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
 
-  export const ripple = async (e: MouseEvent) => {
+  const ripple = async (e: MouseEvent) => {
     const clone = rippleEl.cloneNode(true) as HTMLDivElement;
     rippleEl.parentElement!.appendChild(clone);
     const svg = clone.querySelector("svg")!;
@@ -32,12 +34,19 @@
         },
       ],
       {
-        duration: 650,
+        duration: 425,
         easing: "ease-out",
       },
     ).finished;
     clone.remove();
   };
+
+  onMount(() => {
+    rippleContainer.parentElement?.addEventListener("mousedown", ripple);
+    return () => {
+      rippleContainer.parentElement?.removeEventListener("mousedown", ripple);
+    };
+  });
 </script>
 
 <div class="rippleContainer" bind:this={rippleContainer}>
@@ -139,6 +148,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    overflow: hidden;
   }
 
   .ripple {

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -13,7 +13,6 @@
     };
     const leave = () => {
       clone.style.display = "none";
-      console.log("!");
     };
     const svg = clone.querySelector("svg")!;
     const bounds = rippleEl.getBoundingClientRect();

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -165,7 +165,9 @@
 
   .maskable-noise {
     mask-image: radial-gradient(circle, transparent 10%, black 100%);
+    -webkit-mask-image: radial-gradient(circle, transparent 10%, black 100%);
     mask-size: 100% 100%;
+    -webkit-mask-size: 100% 100%;
     width: 100%;
     height: 100%;
   }

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -34,8 +34,8 @@
         },
       ],
       {
-        duration: 425,
-        easing: "ease-out",
+        duration: 1250,
+        easing: "cubic-bezier(.05,.7,.1,1)",
       },
     ).finished;
     clone.remove();
@@ -51,7 +51,7 @@
 
 <div class="rippleContainer" bind:this={rippleContainer}>
   <div
-    style="background: radial-gradient(circle, rgb(var(--m3-scheme-on-{color}-container)) 20%, transparent);"
+    style="background: radial-gradient(circle, rgb(var(--m3-scheme-on-{color}-container)) 20%, transparent 80%);"
     bind:this={rippleEl}
     class="ripple color-{color}"
   >

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -8,6 +8,13 @@
   const ripple = async (e: MouseEvent) => {
     const clone = rippleEl.cloneNode(true) as HTMLDivElement;
     rippleEl.parentElement!.appendChild(clone);
+    const hover = () => {
+      clone.style.display = "";
+    };
+    const leave = () => {
+      clone.style.display = "none";
+      console.log("!");
+    };
     const svg = clone.querySelector("svg")!;
     const bounds = rippleEl.getBoundingClientRect();
     if (bounds.width > bounds.height) {
@@ -53,6 +60,11 @@
         delay: 250,
       },
     );
+
+    clone.parentElement?.addEventListener("mouseenter", hover);
+    clone.parentElement?.addEventListener("mouseleave", leave);
+    clone.parentElement?.parentElement?.addEventListener("mouseenter", hover);
+    clone.parentElement?.parentElement?.addEventListener("mouseleave", leave);
     await clone.animate(
       [
         {

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -3,7 +3,6 @@
   export let color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
 
   export const ripple = async (e: MouseEvent) => {
-    console.log(rippleEl.parentElement);
     const clone = rippleEl.cloneNode() as HTMLDivElement;
     rippleEl.parentElement!.appendChild(clone);
     const bounds = rippleEl.getBoundingClientRect();

--- a/src/lib/effects/Ripple.svelte
+++ b/src/lib/effects/Ripple.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  let rippleEl: HTMLDivElement;
+  export let color: "primary" | "surface" | "secondary" | "tertiary" = "primary";
+
+  export const ripple = async (e: MouseEvent) => {
+    console.log(rippleEl.parentElement);
+    const clone = rippleEl.cloneNode() as HTMLDivElement;
+    rippleEl.parentElement!.appendChild(clone);
+    const bounds = rippleEl.getBoundingClientRect();
+    if (bounds.width > bounds.height) {
+      clone.style.height = "100%";
+      clone.style.width = clone.offsetHeight + "px";
+    } else {
+      clone.style.width = "100%";
+      clone.style.height = clone.offsetWidth + "px";
+    }
+    // center it at the mouse
+    clone.style.left = e.clientX - bounds.left - clone.offsetWidth / 2 + "px";
+    clone.style.top = e.clientY - bounds.top - clone.offsetHeight / 2 + "px";
+    await clone.animate(
+      [
+        {
+          transform: "scale(0.25)",
+          opacity: 0.25,
+        },
+        {
+          transform: "scale(4)",
+          opacity: 0,
+        },
+      ],
+      {
+        duration: 650,
+        easing: "ease-out",
+      },
+    ).finished;
+    clone.remove();
+  };
+</script>
+
+<div
+  style="background-color: rgb(var(--m3-scheme-on-{color}-container))"
+  bind:this={rippleEl}
+  class="ripple color-{color}"
+/>
+
+<style>
+  .ripple {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: 50%;
+  }
+</style>

--- a/src/lib/forms/Chip.svelte
+++ b/src/lib/forms/Chip.svelte
@@ -2,6 +2,7 @@
   import type { HTMLButtonAttributes } from "svelte/elements";
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
+  import Ripple from "$lib/effects/Ripple.svelte";
 
   export let display = "inline-flex";
   export let extraOptions: HTMLButtonAttributes = {};
@@ -20,17 +21,21 @@
   export let elevated = false;
   export let disabled = false;
   export let selected = false;
+
+  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
   class="m3-container type-{type}"
-  style="display: {display}"
+  style="display: {display}; overflow: hidden;"
   class:elevated
   class:selected
   {disabled}
   on:click
   {...extraOptions}
+  on:mousedown={ripple}
 >
+  <Ripple bind:ripple color="secondary" />
   <div class="layer" />
   {#if icon}
     <Icon {icon} class="leading" />

--- a/src/lib/forms/Chip.svelte
+++ b/src/lib/forms/Chip.svelte
@@ -21,8 +21,6 @@
   export let elevated = false;
   export let disabled = false;
   export let selected = false;
-
-  let ripple: (e: MouseEvent) => Promise<void>;
 </script>
 
 <button
@@ -33,9 +31,8 @@
   {disabled}
   on:click
   {...extraOptions}
-  on:mousedown={ripple}
 >
-  <Ripple bind:ripple color="secondary" />
+  <Ripple color="secondary" />
   <div class="layer" />
   {#if icon}
     <Icon {icon} class="leading" />

--- a/src/lib/nav/Tabs.svelte
+++ b/src/lib/nav/Tabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Ripple from "$lib/effects/Ripple.svelte";
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
   import type { HTMLAttributes, HTMLInputAttributes } from "svelte/elements";
@@ -13,6 +14,10 @@
     value: string;
   }[];
   const name = crypto.randomUUID();
+
+  const ripplers: {
+    [key: string]: (e: MouseEvent) => Promise<void>;
+  } = {};
 </script>
 
 <div
@@ -25,7 +30,14 @@
   {#each items as item}
     {@const id = name + item.value}
     <input type="radio" {name} {id} value={item.value} bind:group={tab} {...extraOptions} />
-    <label for={id} class:tall={item.icon}>
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <label
+      for={id}
+      class:tall={item.icon}
+      style="overflow: hidden;"
+      on:mousedown={ripplers[item.value]}
+    >
+      <Ripple bind:ripple={ripplers[item.value]} color="secondary" />
       {#if item.icon}
         <Icon icon={item.icon} />
       {/if}

--- a/src/lib/nav/Tabs.svelte
+++ b/src/lib/nav/Tabs.svelte
@@ -14,10 +14,6 @@
     value: string;
   }[];
   const name = crypto.randomUUID();
-
-  const ripplers: {
-    [key: string]: (e: MouseEvent) => Promise<void>;
-  } = {};
 </script>
 
 <div
@@ -31,13 +27,8 @@
     {@const id = name + item.value}
     <input type="radio" {name} {id} value={item.value} bind:group={tab} {...extraOptions} />
     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-    <label
-      for={id}
-      class:tall={item.icon}
-      style="overflow: hidden;"
-      on:mousedown={ripplers[item.value]}
-    >
-      <Ripple bind:ripple={ripplers[item.value]} color="secondary" />
+    <label for={id} class:tall={item.icon}>
+      <Ripple color="secondary" />
       {#if item.icon}
         <Icon icon={item.icon} />
       {/if}

--- a/src/lib/nav/VariableTabs.svelte
+++ b/src/lib/nav/VariableTabs.svelte
@@ -59,10 +59,6 @@
     }
   };
   let wrapper: HTMLDivElement;
-  // there is 100% a better way to do this. sorry :3
-  const ripplers: {
-    [key: string]: (e: MouseEvent) => Promise<void>;
-  } = {};
 </script>
 
 <div
@@ -85,13 +81,8 @@
       {...extraOptions}
     />
     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-    <label
-      for={id}
-      class:tall={item.icon}
-      style="overflow: hidden;"
-      on:mousedown={ripplers[item.value]}
-    >
-      <Ripple bind:ripple={ripplers[item.value]} color="secondary" />
+    <label for={id} class:tall={item.icon} style="overflow: hidden;">
+      <Ripple color="secondary" />
       {#if item.icon}
         <Icon icon={item.icon} />
       {/if}

--- a/src/lib/nav/VariableTabs.svelte
+++ b/src/lib/nav/VariableTabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Ripple from "$lib/effects/Ripple.svelte";
   import Icon from "$lib/misc/_icon.svelte";
   import type { IconifyIcon } from "@iconify/types";
   import type { HTMLAttributes, HTMLInputAttributes } from "svelte/elements";
@@ -58,6 +59,10 @@
     }
   };
   let wrapper: HTMLDivElement;
+  // there is 100% a better way to do this. sorry :3
+  const ripplers: {
+    [key: string]: (e: MouseEvent) => Promise<void>;
+  } = {};
 </script>
 
 <div
@@ -79,7 +84,14 @@
       on:input={handleInput}
       {...extraOptions}
     />
-    <label for={id} class:tall={item.icon}>
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <label
+      for={id}
+      class:tall={item.icon}
+      style="overflow: hidden;"
+      on:mousedown={ripplers[item.value]}
+    >
+      <Ripple bind:ripple={ripplers[item.value]} color="secondary" />
       {#if item.icon}
         <Icon icon={item.icon} />
       {/if}

--- a/src/lib/utils/DateField.svelte
+++ b/src/lib/utils/DateField.svelte
@@ -7,6 +7,7 @@
 
   import DatePickerDocked from "$lib/forms/DatePickerDocked.svelte";
   import { easeEmphasized } from "$lib/misc/easing";
+  import Ripple from "$lib/effects/Ripple.svelte";
 
   export let name: string;
   export let date = "";
@@ -59,6 +60,7 @@ opacity: ${Math.min(t * 3, 1)};`,
   />
   <label class="m3-font-body-small" for={id}>{name}</label>
   <button type="button" {disabled} on:click={() => (picker = !picker)}>
+    <Ripple color="secondary" />
     <Icon icon={iconCalendar} />
   </button>
   {#if picker}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,8 +34,6 @@
 
 <Hero />
 <div class="cards">
-  <CardClickable type="elevated"></CardClickable>
-
   <ButtonCard />
   <SegmentedButtonCard />
   <FABCard />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,8 @@
   import TextFieldCard from "./TextFieldCard.svelte";
   import ChipCard from "./ChipCard.svelte";
   import TabsCard from "./TabsCard.svelte";
+  import { Button, Card } from "$lib";
+  import CardClickable from "$lib/containers/CardClickable.svelte";
 </script>
 
 <svelte:head>
@@ -32,6 +34,8 @@
 
 <Hero />
 <div class="cards">
+  <CardClickable type="elevated"></CardClickable>
+
   <ButtonCard />
   <SegmentedButtonCard />
   <FABCard />


### PR DESCRIPTION
this PR adds an albeit rudimentary ripple effect to most clickable components. there's no clear consensus on how ripple *should* look in m3 just yet so this currently replicates a version of what's seen on the [m3 website](https://m3.material.io/), except slightly slower and with a lighter colour to improve accessibility.