### PR TITLE
feat: code samples for component demos

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
     "eslint-plugin-svelte": "^2.43.0",
     "fast-glob": "^3.3.2",
     "globals": "^15.9.0",
+    "highlight.js": "^11.10.0",
     "prettier": "^3.3.2",
     "prettier-plugin-svelte": "^3.2.6",
     "svelte-check": "^3.8.6",
+    "svelte-highlight": "^7.7.0",
     "tslib": "^2.7.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-svelte": "^2.43.0",
     "fast-glob": "^3.3.2",
     "globals": "^15.9.0",
-    "highlight.js": "^11.10.0",
     "prettier": "^3.3.2",
     "prettier-plugin-svelte": "^3.2.6",
     "svelte-check": "^3.8.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       globals:
         specifier: ^15.9.0
         version: 15.9.0
-      highlight.js:
-        specifier: ^11.10.0
-        version: 11.10.0
       prettier:
         specifier: ^3.3.2
         version: 3.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       globals:
         specifier: ^15.9.0
         version: 15.9.0
+      highlight.js:
+        specifier: ^11.10.0
+        version: 11.10.0
       prettier:
         specifier: ^3.3.2
         version: 3.3.3
@@ -63,6 +66,9 @@ importers:
       svelte-check:
         specifier: ^3.8.6
         version: 3.8.6(postcss-load-config@3.1.4(postcss@8.4.40))(postcss@8.4.40)(svelte@4.2.19)
+      svelte-highlight:
+        specifier: ^7.7.0
+        version: 7.7.0
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -768,6 +774,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  highlight.js@11.10.0:
+    resolution: {integrity: sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==}
+    engines: {node: '>=12.0.0'}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -1119,6 +1129,9 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
+
+  svelte-highlight@7.7.0:
+    resolution: {integrity: sha512-umBiTz3fLbbNCA+wGlRhJOb54iC6ap8S/dxjauQ+g6a8oFGTOGQeOP2rJVoh/K1ssF7IjP4P0T3Yuiu+vtaG5Q==}
 
   svelte-hmr@0.16.0:
     resolution: {integrity: sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==}
@@ -1951,6 +1964,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  highlight.js@11.10.0: {}
+
   ignore@5.3.1: {}
 
   ignore@5.3.2: {}
@@ -2286,6 +2301,10 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.4.40)
     optionalDependencies:
       svelte: 4.2.19
+
+  svelte-highlight@7.7.0:
+    dependencies:
+      highlight.js: 11.10.0
 
   svelte-hmr@0.16.0(svelte@4.2.19):
     dependencies:

--- a/src/app.css
+++ b/src/app.css
@@ -3,3 +3,210 @@ body {
   background-color: rgb(var(--m3-scheme-background));
   color: rgb(var(--m3-scheme-on-background));
 }
+
+@media (prefers-color-scheme: light) {
+  pre code.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
+  }
+
+  code.hljs {
+    padding: 3px 5px;
+  }
+
+  .hljs {
+    color: #24292e;
+    background: #ffffff;
+  }
+
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    color: #d73a49;
+  }
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    color: #6f42c1;
+  }
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    color: #005cc5;
+  }
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    color: #032f62;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    color: #e36209;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    color: #6a737d;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    color: #22863a;
+  }
+
+  .hljs-subst {
+    color: #24292e;
+  }
+
+  .hljs-section {
+    color: #005cc5;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    color: #735c0f;
+  }
+
+  .hljs-emphasis {
+    color: #24292e;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    color: #24292e;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    color: #22863a;
+    background-color: #f0fff4;
+  }
+
+  .hljs-deletion {
+    color: #b31d28;
+    background-color: #ffeef0;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  pre code.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
+  }
+
+  code.hljs {
+    padding: 3px 5px;
+  }
+
+  .hljs {
+    color: #c9d1d9;
+    background: #0d1117;
+  }
+
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    color: #ff7b72;
+  }
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    color: #d2a8ff;
+  }
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    color: #79c0ff;
+  }
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    color: #a5d6ff;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    color: #ffa657;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    color: #8b949e;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    color: #7ee787;
+  }
+
+  .hljs-subst {
+    color: #c9d1d9;
+  }
+
+  .hljs-section {
+    color: #1f6feb;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    color: #f2cc60;
+  }
+
+  .hljs-emphasis {
+    color: #c9d1d9;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    color: #c9d1d9;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    color: #aff5b4;
+    background-color: #033a16;
+  }
+
+  .hljs-deletion {
+    color: #ffdcd7;
+    background-color: #67060c;
+  }
+}

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -79,7 +79,10 @@
     color: rgb(var(--m3-scheme-secondary));
     width: 1.5rem;
     height: 1.5rem;
-    margin: 0 auto 1rem auto;
+
+    flex-shrink: 0;
+    align-self: center;
+    margin-bottom: 1rem;
   }
   .headline {
     color: rgb(var(--m3-scheme-on-surface));

--- a/src/routes/BottomSheetCard.svelte
+++ b/src/routes/BottomSheetCard.svelte
@@ -6,8 +6,24 @@
   let open = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Bottom sheet</h2>
+<Card
+  title="Bottom sheet"
+  code={`<BottomSheet on:close={() => (open = false)}>
+  <div>
+    <div>
+      <div>
+        <input type="date" id="d-start" />
+        <label for="d-start">Start</label>
+      </div>
+      <div>
+        <input type="date" id="d-end" />
+        <label for="d-end">End</label>
+      </div>
+    </div>
+    <Button type="filled">Add event</Button>
+  </div>
+</BottomSheet>`}
+>
   <div slot="demo">
     <Button type="tonal" on:click={() => (open = true)}>Open</Button>
     {#if open}
@@ -31,10 +47,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   .contents {
     display: flex;
     flex-direction: column;

--- a/src/routes/ButtonCard.svelte
+++ b/src/routes/ButtonCard.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import Icon from "$lib/misc/_icon.svelte";
-  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import Button from "$lib/buttons/Button.svelte";
   import Switch from "$lib/forms/Switch.svelte";
+  import Icon from "$lib/misc/_icon.svelte";
+  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import Card from "./_card.svelte";
   import Arrows from "./Arrows.svelte";
 
@@ -11,8 +11,12 @@
   let enabled = true;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Button</h2>
+<Card
+  title="Button"
+  code={`<Button {type} disabled={!enabled} {iconType}>
+  Hello
+</Button>`}
+>
   <table>
     <tr>
       <td>
@@ -47,10 +51,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/CardCard.svelte
+++ b/src/routes/CardCard.svelte
@@ -9,8 +9,11 @@
   let clickable = false;
 </script>
 
-<CardCustom>
-  <h2 class="m3-font-headline-large">Card</h2>
+<CardCustom
+  title="Card"
+  code={`<CardClickable {type}>Hello</CardClickable>
+<Card {type}>Hello</Card>`}
+>
   <table>
     <tr>
       <td>
@@ -35,10 +38,6 @@
 </CardCustom>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/CheckboxCard.svelte
+++ b/src/routes/CheckboxCard.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
   import Checkbox from "$lib/forms/Checkbox.svelte";
   import CheckboxAnim from "$lib/forms/CheckboxAnim.svelte";
   import Switch from "$lib/forms/Switch.svelte";
+  import Card from "./_card.svelte";
 
   let animation = true;
   let enabled = true;
   $: component = animation ? CheckboxAnim : Checkbox;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Checkbox</h2>
+<Card
+  title="Checkbox"
+  code={`<CheckboxAnim>
+  <input type="checkbox" checked disabled={!enabled} />
+</CheckboxAnim>
+<Checkbox>
+  <input type="checkbox" checked disabled={!enabled} />
+</Checkbox>`}
+>
   <table>
     <tr>
       <td>
@@ -35,10 +42,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/ChipCard.svelte
+++ b/src/routes/ChipCard.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+  import Chip from "$lib/forms/Chip.svelte";
+  import Switch from "$lib/forms/Switch.svelte";
   import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import iconDropdown from "@ktibow/iconset-material-symbols/expand-more";
   import Card from "./_card.svelte";
-  import Switch from "$lib/forms/Switch.svelte";
   import Arrows from "./Arrows.svelte";
-  import Chip from "$lib/forms/Chip.svelte";
 
   let style: "input" | "assist" | "assist-elevated" | "general" | "general-elevated" = "input";
   let iconType: "none" | "left" | "right" = "none";
@@ -12,8 +12,20 @@
   let selected = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Chip</h2>
+<Card
+  title="Chip"
+  code={`<Chip
+  {type}
+  {elevated}
+  {selected}
+  disabled={!enabled}
+  {icon}
+  {trailingIcon}
+  on:click={() => (selected = !selected)}
+>
+  Hello
+</Chip>`}
+>
   <table>
     <tr>
       <td>
@@ -65,10 +77,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/DateFieldCard.svelte
+++ b/src/routes/DateFieldCard.svelte
@@ -1,18 +1,10 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
   import DateField from "$lib/utils/DateField.svelte";
+  import Card from "./_card.svelte";
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Date field</h2>
+<Card title="Date field" code={`<DateField bind:date />`}>
   <div slot="demo">
     <DateField name="Date" />
   </div>
 </Card>
-
-<style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
-</style>

--- a/src/routes/DialogCard.svelte
+++ b/src/routes/DialogCard.svelte
@@ -1,14 +1,27 @@
 <script lang="ts">
-  import iconTrash from "@ktibow/iconset-material-symbols/delete-outline";
-  import Dialog from "$lib/containers/Dialog.svelte";
   import Button from "$lib/buttons/Button.svelte";
+  import Dialog from "$lib/containers/Dialog.svelte";
+  import iconTrash from "@ktibow/iconset-material-symbols/delete-outline";
   import Card from "./_card.svelte";
 
   let open = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Dialog</h2>
+<Card
+  title="Dialog"
+  code={`<Dialog icon={iconTrash} headline="Permanently delete?" bind:open>
+  Deleting the selected messages will also remove them
+  from all synced devices.
+  <svelte:fragment slot="buttons">
+    <Button type="text" on:click={() => (open = false)}>
+      Cancel
+    </Button>
+    <Button type="tonal" on:click={() => (open = false)}>
+      Delete
+    </Button>
+  </svelte:fragment>
+</Dialog>`}
+>
   <div slot="demo">
     <Button type="tonal" on:click={() => (open = true)}>Open</Button>
     <Dialog icon={iconTrash} headline="Permanently delete?" bind:open>
@@ -20,10 +33,3 @@
     </Dialog>
   </div>
 </Card>
-
-<style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
-</style>

--- a/src/routes/FABCard.svelte
+++ b/src/routes/FABCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import FAB from "$lib/buttons/FAB.svelte";
+  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import Arrows from "./Arrows.svelte";
   import Card from "./_card.svelte";
 
@@ -8,8 +8,15 @@
   let size: "small" | "normal" | "large" | "extended" = "normal";
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">FAB</h2>
+<Card
+  title="FAB"
+  code={`<FAB
+  {color}
+  {size}
+  {icon}
+  text="Hello"
+/>`}
+>
   <table>
     <tr>
       <td>
@@ -35,10 +42,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   table {
     margin-bottom: 1rem;
   }

--- a/src/routes/ListCard.svelte
+++ b/src/routes/ListCard.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import Icon from "$lib/misc/_icon.svelte";
-  import iconUser from "@ktibow/iconset-material-symbols/person-outline";
-  import Divider from "$lib/utils/Divider.svelte";
-  import Checkbox from "$lib/forms/Checkbox.svelte";
   import ListItem from "$lib/containers/ListItem.svelte";
   import ListItemButton from "$lib/containers/ListItemButton.svelte";
   import ListItemLabel from "$lib/containers/ListItemLabel.svelte";
+  import Checkbox from "$lib/forms/Checkbox.svelte";
+  import Icon from "$lib/misc/_icon.svelte";
+  import Divider from "$lib/utils/Divider.svelte";
+  import iconUser from "@ktibow/iconset-material-symbols/person-outline";
   import Card from "./_card.svelte";
   import Arrows from "./Arrows.svelte";
 
@@ -19,8 +19,28 @@
         : "This is an example of supporting text for a list item component showcase.";
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">List</h2>
+<Card
+  title="List"
+  code={`<ListItem headline="This is a headline" supporting={supportingText} {lines}>
+  <svelte:fragment slot="leading">
+    <Icon {icon} />
+  </svelte:fragment>
+</ListItem>
+<Divider />
+<ListItemButton headline="This is a headline" supporting={supportingText} {lines}>
+  <svelte:fragment slot="leading">
+    <Icon {icon} />
+  </svelte:fragment>
+</ListItemButton>
+<Divider />
+<ListItemLabel headline="This is a headline" supporting={supportingText} {lines}>
+  <svelte:fragment slot="leading">
+    <div class="box-wrapper">
+      <Checkbox><input type="checkbox" /></Checkbox>
+    </div>
+  </svelte:fragment>
+</ListItemLabel>`}
+>
   <table>
     <tr>
       <td>
@@ -83,10 +103,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   table {
     margin-bottom: 1rem;
   }

--- a/src/routes/MenuCard.svelte
+++ b/src/routes/MenuCard.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
-  import iconUndo from "@ktibow/iconset-material-symbols/undo";
-  import iconRedo from "@ktibow/iconset-material-symbols/redo";
-  import iconCut from "@ktibow/iconset-material-symbols/content-cut";
-  import Card from "./_card.svelte";
   import Menu from "$lib/containers/Menu.svelte";
   import MenuItem from "$lib/containers/MenuItem.svelte";
   import Switch from "$lib/forms/Switch.svelte";
+  import iconCut from "@ktibow/iconset-material-symbols/content-cut";
+  import iconRedo from "@ktibow/iconset-material-symbols/redo";
+  import iconUndo from "@ktibow/iconset-material-symbols/undo";
+  import Card from "./_card.svelte";
 
   let icons = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Menu</h2>
+<Card
+  title="Menu"
+  code={`<Menu>
+  <MenuItem icon={iconUndo}>Undo</MenuItem>
+  <MenuItem icon={iconRedo} disabled>Redo</MenuItem>
+  <MenuItem icon={iconCut} disabled>Cut</MenuItem>
+</Menu>`}
+>
   <table>
     <tr>
       <td>
@@ -30,10 +36,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/ProgressCard.svelte
+++ b/src/routes/ProgressCard.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
-  import Arrows from "./Arrows.svelte";
-  import Switch from "$lib/forms/Switch.svelte";
-  import LinearProgress from "$lib/forms/LinearProgress.svelte";
-  import LinearProgressIndeterminate from "$lib/forms/LinearProgressIndeterminate.svelte";
   import CircularProgress from "$lib/forms/CircularProgress.svelte";
   import CircularProgressIndeterminate from "$lib/forms/CircularProgressIndeterminate.svelte";
+  import LinearProgress from "$lib/forms/LinearProgress.svelte";
+  import LinearProgressIndeterminate from "$lib/forms/LinearProgressIndeterminate.svelte";
+  import Switch from "$lib/forms/Switch.svelte";
+  import Card from "./_card.svelte";
+  import Arrows from "./Arrows.svelte";
 
   let type = "linear";
   let indeterminate = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Progress</h2>
+<Card
+  title="Progress"
+  code={`<LinearProgressIndeterminate />
+<LinearProgress percent={60} />
+<CircularProgressIndeterminate />
+<CircularProgress percent={60} />`}
+>
   <table>
     <tr>
       <td>

--- a/src/routes/RadioCard.svelte
+++ b/src/routes/RadioCard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
   import RadioAnim1 from "$lib/forms/RadioAnim1.svelte";
   import RadioAnim2 from "$lib/forms/RadioAnim2.svelte";
   import RadioAnim3 from "$lib/forms/RadioAnim3.svelte";
   import Switch from "$lib/forms/Switch.svelte";
+  import Card from "./_card.svelte";
   import Arrows from "./Arrows.svelte";
 
   let animation = "1";
@@ -11,8 +11,12 @@
   $: component = animation == "1" ? RadioAnim1 : animation == "2" ? RadioAnim2 : RadioAnim3;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Radio</h2>
+<Card
+  title="Radio"
+  code={`<RadioAnim1><input type="radio" name="radio" disabled={!enabled} /></RadioAnim1>
+<RadioAnim2><input type="radio" name="radio" disabled={!enabled} /></RadioAnim2>
+<RadioAnim3><input type="radio" name="radio" disabled={!enabled} /></RadioAnim3>`}
+>
   <table>
     <tr>
       <td>
@@ -50,10 +54,6 @@
   .area {
     display: flex;
     gap: 0.5rem;
-  }
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
   }
   label {
     display: flex;

--- a/src/routes/SegmentedButtonCard.svelte
+++ b/src/routes/SegmentedButtonCard.svelte
@@ -1,16 +1,29 @@
 <script>
-  import iconTriangle from "@ktibow/iconset-material-symbols/change-history-outline";
-  import iconSquare from "@ktibow/iconset-material-symbols/square-outline";
-  import iconCircle from "@ktibow/iconset-material-symbols/circle-outline";
-  import Switch from "$lib/forms/Switch.svelte";
   import SegmentedButtonContainer from "$lib/buttons/SegmentedButtonContainer.svelte";
   import SegmentedButtonItem from "$lib/buttons/SegmentedButtonItem.svelte";
+  import Switch from "$lib/forms/Switch.svelte";
+  import iconTriangle from "@ktibow/iconset-material-symbols/change-history-outline";
+  import iconCircle from "@ktibow/iconset-material-symbols/circle-outline";
+  import iconSquare from "@ktibow/iconset-material-symbols/square-outline";
   import Card from "./_card.svelte";
   let multiSelect = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Segmented button</h2>
+<Card
+  title="Segmented button"
+  code={`<SegmentedButtonContainer>
+  <input type="checkbox" id="segmented-0" />
+  <SegmentedButtonItem input="segmented-0">Tab A</SegmentedButtonItem>
+  <input type="checkbox" id="segmented-1" />
+  <SegmentedButtonItem input="segmented-1">Tab B</SegmentedButtonItem>
+</SegmentedButtonContainer>
+<SegmentedButtonContainer>
+<input type="radio" id="segmented-0" />
+  <SegmentedButtonItem input="segmented-0">Tab A</SegmentedButtonItem>
+  <input type="radio" id="segmented-1" />
+  <SegmentedButtonItem input="segmented-1">Tab B</SegmentedButtonItem>
+</SegmentedButtonContainer>`}
+>
   <table>
     <tr>
       <td>
@@ -23,11 +36,11 @@
     {#if multiSelect}
       <SegmentedButtonContainer>
         <input type="checkbox" id="segmented-a-0" />
-        <SegmentedButtonItem input="segmented-a-0">$</SegmentedButtonItem>
+        <SegmentedButtonItem input="segmented-a-0" icon={iconTriangle}>Tab A</SegmentedButtonItem>
         <input type="checkbox" id="segmented-a-1" />
-        <SegmentedButtonItem input="segmented-a-1">$$</SegmentedButtonItem>
+        <SegmentedButtonItem input="segmented-a-1" icon={iconSquare}>Tab B</SegmentedButtonItem>
         <input type="checkbox" id="segmented-a-2" disabled />
-        <SegmentedButtonItem input="segmented-a-2">$$$</SegmentedButtonItem>
+        <SegmentedButtonItem input="segmented-a-2" icon={iconCircle}>Tab C</SegmentedButtonItem>
       </SegmentedButtonContainer>
     {:else}
       <SegmentedButtonContainer>
@@ -43,10 +56,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/SegmentedButtonCard.svelte
+++ b/src/routes/SegmentedButtonCard.svelte
@@ -18,7 +18,7 @@
   <SegmentedButtonItem input="segmented-1">Tab B</SegmentedButtonItem>
 </SegmentedButtonContainer>
 <SegmentedButtonContainer>
-<input type="radio" id="segmented-0" />
+  <input type="radio" id="segmented-0" />
   <SegmentedButtonItem input="segmented-0">Tab A</SegmentedButtonItem>
   <input type="radio" id="segmented-1" />
   <SegmentedButtonItem input="segmented-1">Tab B</SegmentedButtonItem>

--- a/src/routes/SliderCard.svelte
+++ b/src/routes/SliderCard.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
-  import Switch from "$lib/forms/Switch.svelte";
   import Slider from "$lib/forms/Slider.svelte";
-  import Arrows from "./Arrows.svelte";
   import SliderTicks from "$lib/forms/SliderTicks.svelte";
+  import Switch from "$lib/forms/Switch.svelte";
+  import Card from "./_card.svelte";
+  import Arrows from "./Arrows.svelte";
 
   let precision = "continuous";
   let enabled = true;
   let value = 0;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Slider</h2>
+<Card
+  title="Slider"
+  code={`<SliderTicks step={1} max={6} disabled={!enabled} bind:value />
+<Slider step={precision == "continuous" ? "any" : 10} disabled={!enabled} bind:value />`}
+>
   <table>
     <tr>
       <td>
@@ -42,10 +45,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/SnackbarCard.svelte
+++ b/src/routes/SnackbarCard.svelte
@@ -13,7 +13,6 @@
   title="Snackbar"
   code={`<${""}script lang="ts">
   let snackbar: (data: SnackbarIn) => void;
-  let snackbarAnim: (data: SnackbarIn) => void;
 </${""}script>
 <Button
   type="tonal"
@@ -21,7 +20,6 @@
 >
   Show
 </Button>
-<SnackbarAnim bind:show={snackbarAnim} />
 <Snackbar bind:show={snackbar} />`}
 >
   <table>

--- a/src/routes/SnackbarCard.svelte
+++ b/src/routes/SnackbarCard.svelte
@@ -1,16 +1,29 @@
 <script lang="ts">
-  import Switch from "$lib/forms/Switch.svelte";
   import Button from "$lib/buttons/Button.svelte";
   import Snackbar, { type SnackbarIn } from "$lib/containers/Snackbar.svelte";
   import SnackbarAnim from "$lib/containers/SnackbarAnim.svelte";
+  import Switch from "$lib/forms/Switch.svelte";
   import Card from "./_card.svelte";
 
   let snackbar: (data: SnackbarIn) => void;
   let animation = false;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Snackbar</h2>
+<Card
+  title="Snackbar"
+  code={`<${""}script lang="ts">
+  let snackbar: (data: SnackbarIn) => void;
+  let snackbarAnim: (data: SnackbarIn) => void;
+</${""}script>
+<Button
+  type="tonal"
+  on:click={() => snackbar({ message: "Hello", actions: { Undo: () => {} }, closable: true })}
+>
+  Show
+</Button>
+<SnackbarAnim bind:show={snackbarAnim} />
+<Snackbar bind:show={snackbar} />`}
+>
   <table>
     <tr>
       <td>
@@ -33,10 +46,6 @@
 </Card>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   label {
     display: flex;
   }

--- a/src/routes/SwitchCard.svelte
+++ b/src/routes/SwitchCard.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import Card from "./_card.svelte";
   import Switch from "$lib/forms/Switch.svelte";
+  import Card from "./_card.svelte";
 
   let enabled = true;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Switch</h2>
+<Card title="Switch" code={`<Switch disabled={!enabled} />`}>
   <table>
     <tr>
       <td>

--- a/src/routes/TabsCard.svelte
+++ b/src/routes/TabsCard.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import iconSquare from "@ktibow/iconset-material-symbols/square-outline";
-  import iconCircle from "@ktibow/iconset-material-symbols/circle-outline";
-  import iconBald from "@ktibow/iconset-material-symbols/face-5";
-  import Card from "./_card.svelte";
-  import Arrows from "./Arrows.svelte";
   import Switch from "$lib/forms/Switch.svelte";
   import Tabs from "$lib/nav/Tabs.svelte";
   import VariableTabs from "$lib/nav/VariableTabs.svelte";
+  import iconCircle from "@ktibow/iconset-material-symbols/circle-outline";
+  import iconBald from "@ktibow/iconset-material-symbols/face-5";
+  import iconSquare from "@ktibow/iconset-material-symbols/square-outline";
+  import Card from "./_card.svelte";
+  import Arrows from "./Arrows.svelte";
 
   let type = "primary";
   let icons = false;
@@ -27,8 +27,11 @@
 </script>
 
 <span class="anchor" />
-<Card>
-  <h2 class="m3-font-headline-large">Tabs</h2>
+<Card
+  title="Tabs"
+  code={`<VariableTabs bind:tab secondary={false} {items} />
+<Tabs bind:tab secondary {items} />`}
+>
   <table>
     <tr>
       <td>
@@ -70,10 +73,6 @@
   }
   .anchor + :global(div) {
     overflow: hidden;
-  }
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
   }
   label {
     display: flex;

--- a/src/routes/TabsCard.svelte
+++ b/src/routes/TabsCard.svelte
@@ -29,8 +29,8 @@
 <span class="anchor" />
 <Card
   title="Tabs"
-  code={`<VariableTabs bind:tab secondary={false} {items} />
-<Tabs bind:tab secondary {items} />`}
+  code={`<VariableTabs bind:tab {secondary} {items} />
+<Tabs bind:tab {secondary} {items} />`}
 >
   <table>
     <tr>

--- a/src/routes/TextFieldCard.svelte
+++ b/src/routes/TextFieldCard.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
   import Switch from "$lib/forms/Switch.svelte";
   import TextField from "$lib/forms/TextField.svelte";
   import TextFieldMultiline from "$lib/forms/TextFieldMultiline.svelte";
   import TextFieldOutlined from "$lib/forms/TextFieldOutlined.svelte";
   import TextFieldOutlinedMultiline from "$lib/forms/TextFieldOutlinedMultiline.svelte";
+  import iconEdit from "@ktibow/iconset-material-symbols/edit-outline";
+  import type { HTMLInputAttributes } from "svelte/elements";
   import Card from "./_card.svelte";
   import Arrows from "./Arrows.svelte";
-  import type {HTMLInputAttributes, HTMLTextareaAttributes} from "svelte/elements";
 
   let extraOptions: HTMLInputAttributes = {};
   let type = "filled";
@@ -18,8 +18,39 @@
   $: extraOptions.type = option;
 </script>
 
-<Card>
-  <h2 class="m3-font-headline-large">Text field</h2>
+<Card
+  title="Text field"
+  code={`<TextField
+  bind:value
+  name="Field"
+  leadingIcon={leadingIcon ? iconEdit : undefined}
+  error={{errored}
+  {disabled}
+  {extraOptions}
+/>
+<TextFieldOutlined
+  bind:value
+  name="Field"
+  leadingIcon={leadingIcon ? iconEdit : undefined}
+  error={{errored}
+  {disabled}
+  {extraOptions}
+/>
+<TextFieldMultiline
+  bind:value
+  name="Field"
+  {leadingIcon}
+  {error}
+  disabled={!enabled}
+/>
+<TextFieldOutlinedMultiline
+  bind:value
+  name="Field"
+  {leadingIcon}
+  {error}
+  disabled={!enabled}
+/>`}
+>
   <table>
     <tr>
       <td>
@@ -40,10 +71,7 @@
     </tr>
     <tr>
       <td>
-        <Arrows
-          list={["text", "password", "number", "file"]}
-          bind:value={option}
-        />
+        <Arrows list={["text", "password", "number", "file"]} bind:value={option} />
       </td>
       <td>
         {option == "text"
@@ -81,7 +109,7 @@
         leadingIcon={leadingIcon ? iconEdit : undefined}
         error={errored}
         disabled={!enabled}
-        extraOptions={extraOptions}
+        {extraOptions}
         --m3-util-background="var(--m3-scheme-surface-container-low)"
       />
     {:else if type === "outlined"}
@@ -90,7 +118,7 @@
         leadingIcon={leadingIcon ? iconEdit : undefined}
         error={errored}
         disabled={!enabled}
-        extraOptions={extraOptions}
+        {extraOptions}
         --m3-util-background="var(--m3-scheme-surface-container-low)"
       />
     {:else if type === "filled_multiline"}
@@ -116,10 +144,6 @@
 <style>
   .area {
     display: flex;
-  }
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
   }
   label {
     display: flex;

--- a/src/routes/_card.svelte
+++ b/src/routes/_card.svelte
@@ -1,5 +1,47 @@
+<script>
+  import { browser } from "$app/environment";
+  import Button from "$lib/buttons/Button.svelte";
+  import Dialog from "$lib/containers/Dialog.svelte";
+  import Icon from "$lib/misc/_icon.svelte";
+  import iconCode from "@ktibow/iconset-material-symbols/code";
+  import Highlight from "svelte-highlight";
+  import xmlLanguage from "svelte-highlight/languages/xml";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+
+  /** @type {string} */
+  export let title = "";
+  /** @type {string} */
+  export let code = "";
+  let showCode = false;
+
+  $: mediaPrefersDark = browser && window.matchMedia("(prefers-color-scheme: dark)");
+</script>
+
+<svelte:head>
+  {#if mediaPrefersDark}
+    {@html githubDark}
+  {:else}
+    {@html github}
+  {/if}
+</svelte:head>
+
 <div class="container">
   <div class="content">
+    <div>
+      <Button type="text" on:click={() => (showCode = true)}>
+        <Icon icon={iconCode} width="1.5em" height="1.5em" />
+      </Button>
+      <Dialog icon={iconCode} headline="Source Code" bind:open={showCode}>
+        <div class="highlight">
+          <Highlight language={xmlLanguage} {code} />
+        </div>
+        <svelte:fragment slot="buttons">
+          <Button type="tonal" on:click={() => (showCode = false)}>Close</Button>
+        </svelte:fragment>
+      </Dialog>
+    </div>
+    <h2 class="m3-font-headline-large">{title}</h2>
     <slot />
   </div>
   <div class="content">
@@ -8,6 +50,10 @@
 </div>
 
 <style>
+  h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+  }
   .container {
     display: flex;
     flex-direction: column;
@@ -27,5 +73,12 @@
   }
   .content:last-child {
     border-radius: 0.5rem 0.5rem 1.5rem 1.5rem;
+  }
+  .highlight {
+    border-radius: var(--m3-card-shape);
+    overflow: hidden;
+  }
+  .highlight :global(pre) {
+    margin: 0;
   }
 </style>

--- a/src/routes/_card.svelte
+++ b/src/routes/_card.svelte
@@ -1,63 +1,53 @@
 <script>
-  import { browser } from "$app/environment";
   import Button from "$lib/buttons/Button.svelte";
   import Dialog from "$lib/containers/Dialog.svelte";
   import Icon from "$lib/misc/_icon.svelte";
   import iconCode from "@ktibow/iconset-material-symbols/code";
   import Highlight from "svelte-highlight";
   import xmlLanguage from "svelte-highlight/languages/xml";
-  import github from "svelte-highlight/styles/github";
-  import githubDark from "svelte-highlight/styles/github-dark";
 
   /** @type {string} */
   export let title = "";
   /** @type {string} */
   export let code = "";
   let showCode = false;
-
-  $: mediaPrefersDark = browser && window.matchMedia("(prefers-color-scheme: dark)");
 </script>
-
-<svelte:head>
-  {#if mediaPrefersDark}
-    {@html githubDark}
-  {:else}
-    {@html github}
-  {/if}
-</svelte:head>
 
 <div class="container">
   <div class="content">
-    <div>
+    <h2 class="m3-font-headline-large">
+      {title}
       <Button type="text" on:click={() => (showCode = true)}>
         <Icon icon={iconCode} width="1.5em" height="1.5em" />
       </Button>
-      <Dialog icon={iconCode} headline="Source Code" bind:open={showCode}>
-        <div class="highlight">
-          <Highlight language={xmlLanguage} {code} />
-        </div>
-        <svelte:fragment slot="buttons">
-          <Button type="tonal" on:click={() => (showCode = false)}>Close</Button>
-        </svelte:fragment>
-      </Dialog>
-    </div>
-    <h2 class="m3-font-headline-large">{title}</h2>
+    </h2>
     <slot />
   </div>
   <div class="content">
     <slot name="demo" />
   </div>
 </div>
+<Dialog icon={iconCode} headline="Source code" bind:open={showCode}>
+  <div class="highlight">
+    <Highlight language={xmlLanguage} {code} />
+  </div>
+  <svelte:fragment slot="buttons">
+    <Button type="tonal" on:click={() => (showCode = false)}>Close</Button>
+  </svelte:fragment>
+</Dialog>
 
 <style>
-  h2 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-  }
   .container {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+  }
+  h2 {
+    display: flex;
+    justify-content: space-between;
+
+    margin-top: 0;
+    margin-bottom: 1rem;
   }
   .content {
     display: flex;


### PR DESCRIPTION
I was looking through the site and couldn't find a guide as to exactly how to use this lib in code, so I just read the source code of the cards on the site.

Then I thought, "this code would be a perfect demo if you trimmed out the logic for the demo app", so I did just that and added it to the homepage.

This was more an exercise for me to get familiar with the library than anything else, but having already written it anyway I figured I'd clean up my work and offer it as a PR.

---

sample of the new button added to homepage cards:
![sample of the new button added to homepage cards](https://github.com/user-attachments/assets/ddc24da6-73bc-4226-b360-bfbc4f22ee5b)

sample of the dialog opened by the above button:
![sample of the dialog opened by the above button](https://github.com/user-attachments/assets/09e82680-a53e-42c9-b63b-723bbf1ceb11)

wider view of the page, dialog open:
![wider view of the page, dialog open](https://github.com/user-attachments/assets/070221e8-bb3b-4fc1-8ab5-51798eaa011e)