### PR TITLE
Fix missing input name assigns

### DIFF
--- a/scripts/generate-demos.ts
+++ b/scripts/generate-demos.ts
@@ -244,7 +244,7 @@ Here's an example todo list component:
   {/each}
 </div>
 <TextField
-  name="Task name"
+  label="Task name"
   trailingIcon={iconPlus}
   bind:value={newTaskText}
   on:enter={addTask}

--- a/src/demos.md
+++ b/src/demos.md
@@ -777,7 +777,7 @@ let enabled = $state(true);
 Minimal demo:
 
 ```svelte
-<TextField name="Field" bind:value={text} />
+<TextField label="Field" bind:value={text} />
 ```
 
 Full demo:
@@ -838,7 +838,7 @@ let enabled = $state(true);
 {#snippet demo()}
   {#if type === "filled"}
     <TextField
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -846,7 +846,7 @@ let enabled = $state(true);
     />
   {:else if type === "outlined"}
     <TextFieldOutlined
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -854,14 +854,14 @@ let enabled = $state(true);
     />
   {:else if type === "filled_multiline"}
     <TextFieldMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
     />
   {:else if type === "outlined_multiline"}
     <TextFieldOutlinedMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -940,7 +940,7 @@ let items = $derived(
 Minimal demo:
 
 ```svelte
-<DateField name="Date" bind:date />
+<DateField label="Date" bind:date />
 ```
 
 Full demo:
@@ -955,6 +955,6 @@ DateField
 
 ```svelte
 {#snippet demo()}
-  <DateField name="Date" />
+  <DateField label="Date" />
 {/snippet}
 ```

--- a/src/lib/forms/TextField.svelte
+++ b/src/lib/forms/TextField.svelte
@@ -14,8 +14,7 @@
       };
 
   let {
-    name,
-    label = name,
+    label: _label,
     leadingIcon,
     trailingIcon,
     trailingClick,
@@ -26,8 +25,7 @@
     enter,
     ...extra
   }: {
-    name: string;
-    label?: string;
+    label: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -37,6 +35,8 @@
   } & TrailingProps &
     HTMLInputAttributes = $props();
   const id = crypto.randomUUID();
+
+  let label = $derived(_label || extra.name); // TODO: next breaking version, drop name backsupport
 </script>
 
 <div
@@ -51,7 +51,6 @@
     bind:value
     onkeydown={(e) => e.key == "Enter" && enter?.()}
     {id}
-    {name}
     {disabled}
     {required}
     {...extra}

--- a/src/lib/forms/TextField.svelte
+++ b/src/lib/forms/TextField.svelte
@@ -15,6 +15,7 @@
 
   let {
     name,
+    label = name,
     leadingIcon,
     trailingIcon,
     trailingClick,
@@ -26,6 +27,7 @@
     ...extra
   }: {
     name: string;
+    label?: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -49,11 +51,12 @@
     bind:value
     onkeydown={(e) => e.key == "Enter" && enter?.()}
     {id}
+    {name}
     {disabled}
     {required}
     {...extra}
   />
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label class="m3-font-body-large" for={id}>{label}</label>
   <div class="layer"></div>
   {#if leadingIcon}
     <Icon icon={leadingIcon} class="leading" />

--- a/src/lib/forms/TextFieldMultiline.svelte
+++ b/src/lib/forms/TextFieldMultiline.svelte
@@ -4,7 +4,7 @@
   import type { HTMLTextareaAttributes } from "svelte/elements";
 
   let {
-    name,
+    label: _label,
     leadingIcon,
     disabled = false,
     required = false,
@@ -12,7 +12,7 @@
     value = $bindable(""),
     ...extra
   }: {
-    name: string;
+    label: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -34,6 +34,8 @@
       },
     };
   };
+
+  let label = $derived(_label || extra.name); // TODO: next breaking version, drop name backsupport
 </script>
 
 <div class="m3-container" class:leading-icon={leadingIcon} class:error use:resize>
@@ -46,7 +48,7 @@
     {required}
     {...extra}
   ></textarea>
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label class="m3-font-body-large" for={id}>{label}</label>
   <div class="layer"></div>
   {#if leadingIcon}
     <Icon icon={leadingIcon} />

--- a/src/lib/forms/TextFieldOutlined.svelte
+++ b/src/lib/forms/TextFieldOutlined.svelte
@@ -14,8 +14,7 @@
       };
 
   let {
-    name,
-    label = name,
+    label: _label,
     leadingIcon,
     trailingIcon,
     trailingClick,
@@ -26,8 +25,7 @@
     enter,
     ...extra
   }: {
-    name: string;
-    label?: string;
+    label: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -37,6 +35,8 @@
   } & TrailingProps &
     HTMLInputAttributes = $props();
   const id = crypto.randomUUID();
+
+  let label = $derived(_label || extra.name); // TODO: next breaking version, drop name backsupport
 </script>
 
 <div
@@ -51,7 +51,6 @@
     bind:value
     onkeydown={(e) => e.key == "Enter" && enter?.()}
     {id}
-    {name}
     {disabled}
     {required}
     {...extra}

--- a/src/lib/forms/TextFieldOutlined.svelte
+++ b/src/lib/forms/TextFieldOutlined.svelte
@@ -15,6 +15,7 @@
 
   let {
     name,
+    label = name,
     leadingIcon,
     trailingIcon,
     trailingClick,
@@ -26,6 +27,7 @@
     ...extra
   }: {
     name: string;
+    label?: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -49,12 +51,13 @@
     bind:value
     onkeydown={(e) => e.key == "Enter" && enter?.()}
     {id}
+    {name}
     {disabled}
     {required}
     {...extra}
   />
   <div class="layer"></div>
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label class="m3-font-body-large" for={id}>{label}</label>
   {#if leadingIcon}
     <Icon icon={leadingIcon} class="leading" />
   {/if}

--- a/src/lib/forms/TextFieldOutlinedMultiline.svelte
+++ b/src/lib/forms/TextFieldOutlinedMultiline.svelte
@@ -4,7 +4,7 @@
   import type { HTMLTextareaAttributes } from "svelte/elements";
 
   let {
-    name,
+    label: _label,
     leadingIcon,
     disabled = false,
     required = false,
@@ -12,7 +12,7 @@
     value = $bindable(""),
     ...extra
   }: {
-    name: string;
+    label: string;
     leadingIcon?: IconifyIcon;
     disabled?: boolean;
     required?: boolean;
@@ -34,6 +34,8 @@
       },
     };
   };
+
+  let label = $derived(_label || extra.name); // TODO: next breaking version, drop name backsupport
 </script>
 
 <div class="m3-container" class:leading-icon={leadingIcon} class:error use:resize>
@@ -47,7 +49,7 @@
     {...extra}
   ></textarea>
   <div class="layer"></div>
-  <label class="m3-font-body-large" for={id}>{name}</label>
+  <label class="m3-font-body-large" for={id}>{label}</label>
   {#if leadingIcon}
     <Icon icon={leadingIcon} />
   {/if}

--- a/src/lib/utils/DateField.svelte
+++ b/src/lib/utils/DateField.svelte
@@ -11,12 +11,14 @@
 
   let {
     name,
+    label = name,
     date = $bindable(""),
     required = false,
     disabled = false,
     ...extra
   }: {
     name: string;
+    label?: string;
     date?: string;
     required?: boolean;
     disabled?: boolean;
@@ -61,10 +63,11 @@ opacity: ${Math.min(t * 3, 1)};`,
     {disabled}
     {required}
     {id}
+    {name}
     bind:value={date}
     {...extra}
   />
-  <label class="m3-font-body-small" for={id}>{name}</label>
+  <label class="m3-font-body-small" for={id}>{label}</label>
   <button type="button" {disabled} onclick={() => (picker = !picker)}>
     <Layer />
     <Icon icon={iconCalendar} />

--- a/src/lib/utils/DateField.svelte
+++ b/src/lib/utils/DateField.svelte
@@ -10,15 +10,13 @@
   import { easeEmphasized } from "$lib/misc/easing";
 
   let {
-    name,
-    label = name,
+    label: _label,
     date = $bindable(""),
     required = false,
     disabled = false,
     ...extra
   }: {
-    name: string;
-    label?: string;
+    label: string;
     date?: string;
     required?: boolean;
     disabled?: boolean;
@@ -54,6 +52,8 @@ transform: scaleY(${(t * 0.3 + 0.7) * 100}%);
 opacity: ${Math.min(t * 3, 1)};`,
     };
   };
+
+  let label = $derived(_label || extra.name); // TODO: next breaking version, drop name backsupport
 </script>
 
 <div class="m3-container" class:has-js={hasJs} class:disabled use:clickOutside>
@@ -63,7 +63,6 @@ opacity: ${Math.min(t * 3, 1)};`,
     {disabled}
     {required}
     {id}
-    {name}
     bind:value={date}
     {...extra}
   />

--- a/src/routes/16.svelte
+++ b/src/routes/16.svelte
@@ -23,7 +23,7 @@ let { showCode }: { showCode: (
   relevantLinks: { title: string; link: string }[],
 ) => void } = $props();
 
-const minimalDemo = `${"<"}TextField name="Field" bind:value={text} />`;
+const minimalDemo = `${"<"}TextField label="Field" bind:value={text} />`;
 const relevantLinks = [{"title":"TextField.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/forms/TextField.svelte"},{"title":"TextFieldOutlined.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/forms/TextFieldOutlined.svelte"},{"title":"TextFieldMultiline.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/forms/TextFieldMultiline.svelte"},{"title":"TextFieldOutlinedMultiline.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/forms/TextFieldOutlinedMultiline.svelte"}];
 </script>
 
@@ -67,7 +67,7 @@ const relevantLinks = [{"title":"TextField.sv","link":"https://github.com/KTibow
 {#snippet demo()}
   {#if type === "filled"}
     <TextField
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -75,7 +75,7 @@ const relevantLinks = [{"title":"TextField.sv","link":"https://github.com/KTibow
     />
   {:else if type === "outlined"}
     <TextFieldOutlined
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -83,14 +83,14 @@ const relevantLinks = [{"title":"TextField.sv","link":"https://github.com/KTibow
     />
   {:else if type === "filled_multiline"}
     <TextFieldMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
     />
   {:else if type === "outlined_multiline"}
     <TextFieldOutlinedMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}

--- a/src/routes/18.svelte
+++ b/src/routes/18.svelte
@@ -15,12 +15,12 @@ let { showCode }: { showCode: (
   relevantLinks: { title: string; link: string }[],
 ) => void } = $props();
 
-const minimalDemo = `${"<"}DateField name="Date" bind:date />`;
+const minimalDemo = `${"<"}DateField label="Date" bind:date />`;
 const relevantLinks = [{"title":"DateField.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/utils/DateField.svelte"}];
 </script>
 
 <InternalCard title="Date field" showCode={() => showCode("Date field", minimalDemo, relevantLinks)}>
 {#snippet demo()}
-  <DateField name="Date" />
+  <DateField label="Date" />
 {/snippet}
 </InternalCard>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -164,7 +164,7 @@ Here's an example todo list component:
   {/each}
 </div>
 <TextField
-  name="Task name"
+  label="Task name"
   trailingIcon={iconPlus}
   bind:value={newTaskText}
   on:enter={addTask}
@@ -1155,7 +1155,7 @@ The M3 Svelte interactive demo for this component uses Switch with the TS `let e
 
 Minimal demo:
 ```svelte
-<TextField name="Field" bind:value={text} />
+<TextField label="Field" bind:value={text} />
 ```
 
 The M3 Svelte interactive demo for this component uses TextField, TextFieldOutlined, TextFieldMultiline, TextFieldOutlinedMultiline with the TS `import type { HTMLInputAttributes } from "svelte/elements";
@@ -1204,7 +1204,7 @@ let enabled = $state(true);` to make this demo:
 {#snippet demo()}
   {#if type === "filled"}
     <TextField
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -1212,7 +1212,7 @@ let enabled = $state(true);` to make this demo:
     />
   {:else if type === "outlined"}
     <TextFieldOutlined
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -1220,14 +1220,14 @@ let enabled = $state(true);` to make this demo:
     />
   {:else if type === "filled_multiline"}
     <TextFieldMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
     />
   {:else if type === "outlined_multiline"}
     <TextFieldOutlinedMultiline
-      name="Field"
+      label="Field"
       leadingIcon={leadingIcon ? iconCircle : undefined}
       error={errored}
       disabled={!enabled}
@@ -1294,13 +1294,13 @@ let items = $derived(
 
 Minimal demo:
 ```svelte
-<DateField name="Date" bind:date />
+<DateField label="Date" bind:date />
 ```
 
 The M3 Svelte interactive demo for this component uses DateField with the TS `` to make this demo:
 ```svelte
 {#snippet demo()}
-  <DateField name="Date" />
+  <DateField label="Date" />
 {/snippet}
 ```
 


### PR DESCRIPTION
Fixes the `name` attribute of components that wrap the `<input>` element not being assigned as the HTML attribute. Additionally, adds a `label` attribute which defaults to `name` to allow labels to be different from names.