### PR TITLE
Add support for link list items

### DIFF
--- a/src/lib/containers/ListItem.svelte
+++ b/src/lib/containers/ListItem.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import type { HTMLAttributes, HTMLButtonAttributes, HTMLLabelAttributes } from "svelte/elements";
+  import type {
+    HTMLAnchorAttributes,
+    HTMLAttributes,
+    HTMLButtonAttributes,
+    HTMLLabelAttributes,
+  } from "svelte/elements";
   import Layer from "$lib/misc/Layer.svelte";
 
   type ActionProps =
     | HTMLAttributes<HTMLDivElement>
     | ({ click: () => void } & HTMLButtonAttributes)
-    | ({ label: true } & HTMLLabelAttributes);
+    | ({ label: true } & HTMLLabelAttributes)
+    | ({ href: string } & HTMLAnchorAttributes);
 
   let props: {
     leading?: Snippet;
@@ -78,6 +84,12 @@
     <Layer />
     {@render content(leading, overline, headline, supporting, trailing)}
   </button>
+{:else if "href" in props}
+  {@const { leading, overline = "", headline = "", supporting = "", trailing, ...extra } = props}
+  <a class="m3-container lines-{_lines}" {...extra}>
+    <Layer />
+    {@render content(leading, overline, headline, supporting, trailing)}
+  </a>
 {:else}
   {@const { leading, overline = "", headline = "", supporting = "", trailing, ...extra } = props}
   <div class="m3-container lines-{_lines}" {...extra}>

--- a/src/routes/5.svelte
+++ b/src/routes/5.svelte
@@ -12,7 +12,7 @@ import Divider from "$lib/utils/Divider.svelte";
 const headline = "Hello";
 
 let lines: "1" | "2" | "3" = $state("1");
-let type: "div" | "button" | "label" = $state("div");
+let type: "div" | "button" | "label" | "a" = $state("div");
 
 let supporting = $derived(
   lines == "1"
@@ -42,7 +42,7 @@ const relevantLinks = [{"title":"ListItem.sv","link":"https://github.com/KTibow/
   {lines == "1" ? "line" : "lines"}
 </label>
 <label>
-  <Arrows list={["div", "button", "label"]} bind:value={type} />
+  <Arrows list={["div", "button", "label", "a"]} bind:value={type} />
   {"<" + type + ">"}
 </label>
 {#snippet demo()}
@@ -61,7 +61,7 @@ const relevantLinks = [{"title":"ListItem.sv","link":"https://github.com/KTibow/
       {headline}
       {supporting}
       lines={+lines}
-      {...type == "label" ? { label: true } : type == "button" ? { click: () => {} } : {}}
+      {...type == "label" ? { label: true } : type == "button" ? { click: () => {} } : type == "a" ? { href: "/" } : {}}
     />
     <Divider />
     <ListItem
@@ -69,7 +69,7 @@ const relevantLinks = [{"title":"ListItem.sv","link":"https://github.com/KTibow/
       {headline}
       {supporting}
       lines={+lines}
-      {...type == "label" ? { label: true } : type == "button" ? { click: () => {} } : {}}
+      {...type == "label" ? { label: true } : type == "button" ? { click: () => {} } : type == "a" ? { href: "/" } : {}}
     />
   </div>
 {/snippet}


### PR DESCRIPTION
Adds support for using links/anchors as ListItem's element.

Usage:

```svelte
<ListItem href="/" headline="My Link" />
```