### PR TITLE
Add `LoadingIndicator` export in lib index

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,6 +29,7 @@ export { default as WavyLinearProgressEstimate } from "./forms/WavyLinearProgres
 export { default as CircularProgress } from "./forms/CircularProgress.svelte";
 export { default as CircularProgressEstimate } from "./forms/CircularProgressEstimate.svelte";
 export { default as CircularProgressIndeterminate } from "./forms/CircularProgressIndeterminate.svelte";
+export { default as LoadingIndicator } from "./forms/LoadingIndicator.svelte"
 export { default as RadioAnim1 } from "./forms/RadioAnim1.svelte";
 export { default as RadioAnim2 } from "./forms/RadioAnim2.svelte";
 export { default as RadioAnim3 } from "./forms/RadioAnim3.svelte";


### PR DESCRIPTION
This pull request adds a missing export for the `LoadingIndicator` component in the library's main index file.
Without this export, the component cannot be imported directly from the library package.