### PR TITLE
Specify the m3-util-background variable for compatible containers

### DIFF
--- a/src/lib/containers/Card.svelte
+++ b/src/lib/containers/Card.svelte
@@ -39,7 +39,7 @@
     border: none;
     border-radius: var(--m3-card-shape);
     background-color: rgb(var(--m3-scheme-surface));
-    --m3-util-background: rgb(var(--m3-scheme-surface));
+    --m3-util-background: var(--m3-scheme-surface);
     color: rgb(var(--m3-scheme-on-surface));
   }
 
@@ -61,12 +61,12 @@
 
   .elevated {
     background-color: rgb(var(--m3-scheme-surface-container-low));
-    --m3-util-background: rgb(var(--m3-scheme-surface-container-low));
+    --m3-util-background: var(--m3-scheme-surface-container-low);
     box-shadow: var(--m3-util-elevation-1);
   }
   .filled {
     background-color: rgb(var(--m3-scheme-surface-container-highest));
-    --m3-util-background: rgb(var(--m3-scheme-surface-container-highest));
+    --m3-util-background: var(--m3-scheme-surface-container-highest);
   }
   .outlined {
     border: solid 1px rgb(var(--m3-scheme-outline-variant));

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -77,7 +77,7 @@
     display: flex;
     flex-direction: column;
     background-color: rgb(var(--m3-scheme-surface-container-high));
-    --m3-util-background: rgb(var(--m3-scheme-surface-container-high));
+    --m3-util-background: var(--m3-scheme-surface-container-high);
     border: none;
     border-radius: var(--m3-dialog-shape);
     min-width: 17.5rem;


### PR DESCRIPTION
Adds the `--m3-util-background` CSS variable to containers where TextFields may appear (Dialog, Card).