### PR TITLE
SplitButton: optically center trailing button

### DIFF
--- a/src/lib/buttons/SplitButton.svelte
+++ b/src/lib/buttons/SplitButton.svelte
@@ -101,8 +101,7 @@
     position: relative;
     transition:
       box-shadow var(--m3-util-easing-fast),
-      border-radius var(--m3-util-easing-fast),
-      padding var(--m3-util-easing-fast);
+      border-radius var(--m3-util-easing-fast);
   }
 
   button {
@@ -129,21 +128,21 @@
     position: relative;
   }
   summary {
-    /* correction = coef * (startCornerRadius - endCornerRadius) */
-    --_inner-shape: var(--m3-split-button-inner-shape);
-    --_correction: calc(var(--m3-util-centering-optical-coefficient) * (var(--_inner-shape) - 1.25rem));
-    padding-inline-start: round(calc(0.8125rem + var(--_correction)), 1px);
-    padding-inline-end: round(calc(0.8125rem - var(--_correction)), 1px);
-    border-start-start-radius: var(--_inner-shape);
-    border-end-start-radius: var(--_inner-shape);
+    width: 3rem;
+
+    --inner-shape: var(--m3-split-button-inner-shape);
+    --outer-shape: var(--m3-split-button-outer-shape);
+    border-start-start-radius: var(--inner-shape);
+    border-end-start-radius: var(--inner-shape);
+    border-start-end-radius: var(--outer-shape);
+    border-end-end-radius: var(--outer-shape);
+
     &:hover,
     &:active {
-      --_inner-shape: var(--m3-split-button-half-shape);
+      --inner-shape: var(--m3-split-button-half-shape);
     }
-    border-start-end-radius: var(--m3-split-button-outer-shape);
-    border-end-end-radius: var(--m3-split-button-outer-shape);
     &:is(details[open] summary) {
-      --_inner-shape: var(--m3-split-button-outer-shape);
+      --inner-shape: var(--m3-split-button-outer-shape);
       > :global(.tint) {
         opacity: 0.08;
       }
@@ -152,7 +151,13 @@
       }
     }
     > :global(svg) {
-      transition: rotate var(--m3-util-easing-fast);
+      /* Push away from the most rounded side */
+      --shape-delta: calc(var(--inner-shape) - var(--outer-shape));
+      --correction: calc(var(--m3-util-optical-centering-coefficient) * var(--shape-delta));
+      translate: var(--correction) 0;
+      transition:
+        rotate var(--m3-util-easing-fast),
+        translate var(--m3-util-easing-fast);
     }
   }
   details > :global(:not(summary)) :global {

--- a/src/lib/buttons/SplitButton.svelte
+++ b/src/lib/buttons/SplitButton.svelte
@@ -129,21 +129,21 @@
     position: relative;
   }
   summary {
-    padding-inline-start: 0.75rem;
-    padding-inline-end: 0.875rem;
-    border-start-start-radius: var(--m3-split-button-inner-shape);
-    border-end-start-radius: var(--m3-split-button-inner-shape);
+    /* correction = coef * (startCornerRadius - endCornerRadius) */
+    --_inner-shape: var(--m3-split-button-inner-shape);
+    --_correction: calc(var(--m3-util-centering-optical-coefficient) * (var(--_inner-shape) - 1.25rem));
+    padding-inline-start: round(calc(0.8125rem + var(--_correction)), 1px);
+    padding-inline-end: round(calc(0.8125rem - var(--_correction)), 1px);
+    border-start-start-radius: var(--_inner-shape);
+    border-end-start-radius: var(--_inner-shape);
     &:hover,
     &:active {
-      border-start-start-radius: var(--m3-split-button-half-shape);
-      border-end-start-radius: var(--m3-split-button-half-shape);
+      --_inner-shape: var(--m3-split-button-half-shape);
     }
     border-start-end-radius: var(--m3-split-button-outer-shape);
     border-end-end-radius: var(--m3-split-button-outer-shape);
     &:is(details[open] summary) {
-      padding-inline-start: 0.8125rem;
-      padding-inline-end: 0.8125rem;
-      border-radius: var(--m3-split-button-outer-shape);
+      --_inner-shape: var(--m3-split-button-outer-shape);
       > :global(.tint) {
         opacity: 0.08;
       }

--- a/src/lib/misc/styles.css
+++ b/src/lib/misc/styles.css
@@ -31,7 +31,7 @@
   --m3-util-rounding-large: 16px;
   --m3-util-rounding-extra-large: 28px;
   --m3-util-rounding-full: 9999px;
-  --m3-util-centering-optical-coefficient: 0.11;
+  --m3-util-optical-centering-coefficient: 0.11;
 
   --m3-font: Roboto, system-ui, sans-serif;
 

--- a/src/lib/misc/styles.css
+++ b/src/lib/misc/styles.css
@@ -31,6 +31,7 @@
   --m3-util-rounding-large: 16px;
   --m3-util-rounding-extra-large: 28px;
   --m3-util-rounding-full: 9999px;
+  --m3-util-centering-optical-coefficient: 0.11;
 
   --m3-font: Roboto, system-ui, sans-serif;
 


### PR DESCRIPTION
According to the spec, this behavior should only be present on the trailing button, not on the leading one.

Coefficient comes from Compose Material 3 [1].

Also, please note that rounding to the nearest `px` rather than to the nearest `rem` is intentional and better mimics the behavior witnessable in Compose M3.

This change also slightly alters padding measurements—11 and 15px, rather than the 12 and 14px of the spec [2]. I believe the rounding error lies in the spec.

## Screenshots
### Enabled
<img width="204" height="110" alt="image" src="https://github.com/user-attachments/assets/aeccceb4-da5d-4e0b-b1da-37cefcff0222" />

### Hovered
<img width="216" height="95" alt="image" src="https://github.com/user-attachments/assets/e1b483c6-bc1a-4036-880d-0715d65652d6" />

### Pressed
<img width="227" height="106" alt="image" src="https://github.com/user-attachments/assets/bb8e4331-56dd-4482-8d19-b145b379ff5e" />

### Active
<img width="301" height="320" alt="image" src="https://github.com/user-attachments/assets/69e7c246-bb55-47d3-abc3-6ad3473edbc4" />

---
[1] https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/HorizontalCenterOptically.kt#91
[2] https://m3.material.io/components/split-button/specs#2a1bfc70-e042-485e-a5e2-b2d464b97fd8