### PR TITLE
elevation: use spot/ambient box shadows

### DIFF
--- a/src/lib/misc/styles.css
+++ b/src/lib/misc/styles.css
@@ -2,25 +2,20 @@
 :root {
   --m3-util-elevation-0: none;
   --m3-util-elevation-1:
-    0px 3px 1px -2px rgb(var(--m3-scheme-shadow) / 0.2),
-    0px 2px 2px 0px rgb(var(--m3-scheme-shadow) / 0.14),
-    0px 1px 5px 0px rgb(var(--m3-scheme-shadow) / 0.12);
+    0px 1px 2px 0px rgb(var(--m3-scheme-shadow) / 0.3),  /* Spot */
+    0px 1px 3px 1px rgb(var(--m3-scheme-shadow) / 0.15); /* Ambient */
   --m3-util-elevation-2:
-    0px 2px 4px -1px rgb(var(--m3-scheme-shadow) / 0.2),
-    0px 4px 5px 0px rgb(var(--m3-scheme-shadow) / 0.14),
-    0px 1px 10px 0px rgb(var(--m3-scheme-shadow) / 0.12);
+    0px 1px 2px 0px rgb(var(--m3-scheme-shadow) / 0.3),
+    0px 2px 6px 2px rgb(var(--m3-scheme-shadow) / 0.15);
   --m3-util-elevation-3:
-    0px 5px 5px -3px rgb(var(--m3-scheme-shadow) / 0.2),
-    0px 8px 10px 1px rgb(var(--m3-scheme-shadow) / 0.14),
-    0px 3px 14px 2px rgb(var(--m3-scheme-shadow) / 0.12);
+    0px 1px 3px 0px rgb(var(--m3-scheme-shadow) / 0.3),
+    0px 4px 8px 3px rgb(var(--m3-scheme-shadow) / 0.15);
   --m3-util-elevation-4:
-    0px 5px 5px -3px rgb(var(--m3-scheme-shadow) / 0.2),
-    0px 8px 10px 1px rgb(var(--m3-scheme-shadow) / 0.14),
-    0px 3px 14px 2px rgb(var(--m3-scheme-shadow) / 0.12);
+    0px 2px 3px 0px rgb(var(--m3-scheme-shadow) / 0.3),
+    0px 6px 10px 4px rgb(var(--m3-scheme-shadow) / 0.15);
   --m3-util-elevation-5:
-    0px 8px 10px -6px rgb(var(--m3-scheme-shadow) / 0.2),
-    0px 16px 24px 2px rgb(var(--m3-scheme-shadow) / 0.14),
-    0px 6px 30px 5px rgb(var(--m3-scheme-shadow) / 0.12);
+    0px 4px 4px 0px rgb(var(--m3-scheme-shadow) / 0.3),
+    0px 8px 12px 6px rgb(var(--m3-scheme-shadow) / 0.15);
   --m3-util-bottom-offset: 0;
 
   /* Shapes */


### PR DESCRIPTION
This is more accurate to the rendering of shadow elevation on Android. Values come from Material Web [1].

## Screenshots
### FAB (Elevation level 3)
Before
<img width="91" height="84" alt="image" src="https://github.com/user-attachments/assets/a708d3e5-08e3-4f0c-8a65-ecd395af0c71" />
After
<img width="82" height="81" alt="image" src="https://github.com/user-attachments/assets/78563115-03b0-4690-a484-e6150b9c0b8d" />

### Menu (Elevation level 2)
Before
<img width="317" height="187" alt="image" src="https://github.com/user-attachments/assets/1213c0f8-4027-4b2f-851f-ab1b76e48893" />
After
<img width="305" height="184" alt="image" src="https://github.com/user-attachments/assets/d8be9fa3-a9d9-4064-a219-22ac311e5f80" />

### Button (Elevation level 1)
Before
<img width="132" height="74" alt="image" src="https://github.com/user-attachments/assets/56d6bab1-1aba-4954-8829-c53d65c8e304" />
After (better top separation)
<img width="106" height="67" alt="image" src="https://github.com/user-attachments/assets/534b9c2d-4977-44e4-95d3-e1bd84bb33e0" />

---
[1] https://github.com/material-components/material-web/blob/cd7512ff90cf25ad98c6caa9842bf86d284146c7/elevation/internal/_elevation.scss#L62