### PR TITLE
JS-less dialog closing

### DIFF
--- a/src/demos.md
+++ b/src/demos.md
@@ -463,7 +463,7 @@ Minimal demo:
 <Dialog headline="Hello" bind:open>
   I'm alive
   {#snippet buttons()}
-    <Button variant="tonal" onclick={() => (open = false)}>OK</Button>
+    <Button variant="tonal">OK</Button>
   {/snippet}
 </Dialog>
 ```
@@ -486,7 +486,7 @@ let open = $state(false);
     Anything is possible at ZomboCom! You can do anything at ZomboCom! The infinite is possible at
     ZomboCom! The unattainable is unknown at ZomboCom!
     {#snippet buttons()}
-      <Button variant="tonal" onclick={() => (open = false)}>OK</Button>
+      <Button variant="tonal">OK</Button>
     {/snippet}
   </Dialog>
 {/snippet}

--- a/src/lib/buttons/Button.svelte
+++ b/src/lib/buttons/Button.svelte
@@ -61,7 +61,7 @@
 {:else}
   {@const { variant = "filled", square = false, iconType = "none", children, ...extra } = props}
   <button
-    type={"onclick" in extra ? "button" : undefined}
+    type={"onclick" in extra ? "button" : "submit"}
     class="m3-container m3-font-label-large {variant} icon-{iconType}"
     class:square
     {...extra}

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -53,10 +53,6 @@
       extra.onClick();
     }
   }}
-  onclose={(e) => {
-    if (e.target != e.currentTarget) return;
-    open = false;
-  }}
   bind:this={dialog}
   closedby={closedby ||
     (extra.closeOnClick == false && extra.closeOnEsc == false

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -55,6 +55,10 @@
       open = false;
     }
   }}
+  onclose={(e) => {
+    if (e.target != e.currentTarget) return;
+    open = false;
+  }}
   bind:this={dialog}
   {...extra}
 >
@@ -66,9 +70,9 @@
     <div class="content m3-font-body-medium">
       {@render children()}
     </div>
-    <div class="buttons">
+    <form method="dialog" class="buttons">
       {@render buttons()}
-    </div>
+    </form>
   </div>
 </dialog>
 

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -60,6 +60,7 @@
       : extra.closeOnClick == false
         ? "closerequest"
         : "any")}
+  role="alertdialog"
   {...extra}
 >
   {#if icon}

--- a/src/lib/containers/Dialog.svelte
+++ b/src/lib/containers/Dialog.svelte
@@ -3,7 +3,6 @@
   import type { HTMLDialogAttributes } from "svelte/elements";
   import type { Snippet } from "svelte";
   import Icon from "$lib/misc/_icon.svelte";
-  import Divider from "$lib/utils/Divider.svelte";
 
   let {
     icon,

--- a/src/routes/8.svelte
+++ b/src/routes/8.svelte
@@ -19,7 +19,7 @@ let { showCode }: { showCode: (
 const minimalDemo = `${"<"}Dialog headline="Hello" bind:open>
   I'm alive
   {#snippet buttons()}
-    ${"<"}Button variant="tonal" onclick={() => (open = false)}>OK${"<"}/Button>
+    ${"<"}Button variant="tonal">OK${"<"}/Button>
   {/snippet}
 ${"<"}/Dialog>`;
 const relevantLinks = [{"title":"Dialog.sv","link":"https://github.com/KTibow/m3-svelte/blob/main/src/lib/containers/Dialog.svelte"}];
@@ -32,7 +32,7 @@ const relevantLinks = [{"title":"Dialog.sv","link":"https://github.com/KTibow/m3
     Anything is possible at ZomboCom! You can do anything at ZomboCom! The infinite is possible at
     ZomboCom! The unattainable is unknown at ZomboCom!
     {#snippet buttons()}
-      <Button variant="tonal" onclick={() => (open = false)}>OK</Button>
+      <Button variant="tonal">OK</Button>
     {/snippet}
   </Dialog>
 {/snippet}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -931,7 +931,7 @@ Minimal demo:
 <Dialog headline="Hello" bind:open>
   I'm alive
   {#snippet buttons()}
-    <Button variant="tonal" onclick={() => (open = false)}>OK</Button>
+    <Button variant="tonal">OK</Button>
   {/snippet}
 </Dialog>
 ```
@@ -944,7 +944,7 @@ The M3 Svelte interactive demo for this component uses Button, Dialog with the T
     Anything is possible at ZomboCom! You can do anything at ZomboCom! The infinite is possible at
     ZomboCom! The unattainable is unknown at ZomboCom!
     {#snippet buttons()}
-      <Button variant="tonal" onclick={() => (open = false)}>OK</Button>
+      <Button variant="tonal">OK</Button>
     {/snippet}
   </Dialog>
 {/snippet}


### PR DESCRIPTION
Changes the container of the `buttons` snippet to a `<form method="dialog">` to allow JS-less closing. This shouldn't be a breaking change, because submit buttons already needed the `form` attribute to submit a form in a dialog; otherwise, they were invalid.

The `type` of `<Button>`s has been changed to an explicit `"submit"` to silence browser warnings. This shouldn't matter too much, since it already defaults to `"button"` if an onclick handler is present.