### PR TITLE
use DateField.vue floating picker

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data style="margin-bottom:500px" class="m3-font-body-large">
+  <body data-sveltekit-preload-data class="m3-font-body-large">
     <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data class="m3-font-body-large">
+  <body data-sveltekit-preload-data style="margin-bottom:500px" class="m3-font-body-large">
     <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -107,6 +107,14 @@ opacity: ${Math.min(t * 3, 1)};`,
           position-area: top;
           margin-bottom: 1rem;
         }
+        @position-try --picker-bottom-left {
+            position-area: bottom left;
+            margin-bottom: 1rem;
+        }
+        @position-try --picker-top-left {
+            position-area: top left;
+            margin-bottom: 1rem;
+        }
     }
 
 
@@ -115,7 +123,6 @@ opacity: ${Math.min(t * 3, 1)};`,
   }
   .m3-container {
     position: relative;
-    anchor-name: var(--anchor-name);
     height: calc(3.5rem + var(--m3-util-density-term));
     min-width: 15rem;
     background-color: rgb(var(--m3-scheme-surface-container-highest));
@@ -158,6 +165,7 @@ opacity: ${Math.min(t * 3, 1)};`,
     padding-right: 0.75rem;
     height: 100%;
     inset-inline-end: 0;
+    anchor-name: var(--anchor-name);
 
     align-items: center;
     justify-content: center;
@@ -199,12 +207,13 @@ opacity: ${Math.min(t * 3, 1)};`,
         .picker {
             position: fixed;
             position-anchor: var(--anchor-name);
-            position-area: bottom;
+            position-area: bottom left;
             margin-top: 1rem;
+            margin-right: -48px /* button width * 2 */;
             position-try-fallbacks:
-                --picker-bottom, --picker-top, bottom right, bottom left, top right, top left;
+                --picker-bottom, --picker-top,
+                --picker-bottom-left, --picker-top-left;
             z-index: 1;
-            translate: 15% 0;
         }
     }
 

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -166,7 +166,6 @@ opacity: ${Math.min(t * 3, 1)};`,
     height: 100%;
     inset-inline-end: 0;
     anchor-name: var(--anchor-name);
-
     align-items: center;
     justify-content: center;
     border: none;
@@ -209,7 +208,7 @@ opacity: ${Math.min(t * 3, 1)};`,
             position-anchor: var(--anchor-name);
             position-area: bottom left;
             margin-top: 1rem;
-            margin-right: -48px /* button width * 2 */;
+            margin-right: -3rem;
             position-try-fallbacks:
                 --picker-bottom, --picker-top,
                 --picker-bottom-left, --picker-top-left;

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -26,49 +26,11 @@
     datePickerTitle?: string;
   } & HTMLInputAttributes = $props();
 
-  const ANIMATION_DURATION = 400;
-
-  let positionTranslate = $state<string>();
-  let paddingTranslate = $state<string>();
-
   const id = $props.id();
   let hasJs = $state(false);
   onMount(() => {
     hasJs = true;
-    return () => {
-      if (intervalId) clearTimeout(intervalId);
-    };
   });
-
-
-  function detectPickerPosition(element: HTMLElement): { position: string; padding: string } {
-    const rect = element.getBoundingClientRect();
-    const windowHeight = window.innerHeight;
-    const middleOfScreen = windowHeight / 2;
-    return rect.top < middleOfScreen
-      ? { position: '0%',                       padding: '1rem'  }
-      : { position: `-100% - ${rect.height}px`, padding: '-1rem' };
-  }
-
-  let intervalId: number
-
-  const toggleModal = () => {
-    let isOpen = picker = !picker;
-    if (intervalId) clearTimeout(intervalId);
-    if (isOpen) {
-      const element = document.getElementById(id);
-      if (element instanceof HTMLElement) {
-        const { position, padding } = detectPickerPosition(element);
-        positionTranslate = position;
-        paddingTranslate = padding;
-      }
-    } else {
-      intervalId = setTimeout(() => {
-        positionTranslate = undefined
-        paddingTranslate = undefined
-      }, ANIMATION_DURATION);
-    }
-  }
 
   let picker = $state(false);
   const clickOutside = (container: Node) => {
@@ -86,7 +48,7 @@
   };
   const enterExit = (_: Node): TransitionConfig => {
     return {
-      duration: ANIMATION_DURATION,
+      duration: 400,
       easing: easeEmphasized,
       css: (t, u) => `clip-path: inset(-100% 0 ${u * 100}% 0 round 1rem);
 transform-origin: top;
@@ -96,34 +58,20 @@ opacity: ${Math.min(t * 3, 1)};`,
   };
 </script>
 
-<div
-    class="m3-container"
-    class:has-js={hasJs}
-    class:disabled
-    class:error
-    use:clickOutside
-    style:--position-translate={positionTranslate}
-    style:--padding-translate={paddingTranslate}
->
-
-    <input
-        type="date"
-        class="focus-none m3-font-body-large"
-        {disabled}
-        {required}
-        {id}
-        bind:value
-        {...extra}
-        defaultValue={extra.defaultValue}
-    />
-  <!-- TODO: once https://github.com/sveltejs/svelte/pull/16481 is finished, remove the defaultvalue thing -->
+<div class="m3-container" class:has-js={hasJs} class:disabled class:error use:clickOutside>
+  <input
+    type="date"
+    class="focus-none m3-font-body-large"
+    {disabled}
+    {required}
+    {id}
+    bind:value
+    {...extra}
+    defaultValue={extra.defaultValue}
+  />
+  <!-- TODO/deprecated: once https://github.com/sveltejs/svelte/pull/16481 is finished, remove the defaultvalue thing -->
   <label class="m3-font-body-small" for={id}>{label}</label>
-  <button
-      type="button"
-      {disabled}
-      title={datePickerTitle}
-      onclick={() => toggleModal()}
-  >
+  <button type="button" {disabled} title={datePickerTitle} onclick={() => (picker = !picker)}>
     <Layer />
     <Icon icon={iconCalendar} width="1.5rem" height="1.5rem" />
   </button>
@@ -217,8 +165,7 @@ opacity: ${Math.min(t * 3, 1)};`,
 
   .picker {
     position: absolute;
-    top: 100%;
-    translate: 0 calc(var(--position-translate) + var(--padding-translate));
+    top: calc(100% + 1rem);
     right: 0;
     z-index: 1;
   }

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -58,7 +58,14 @@ opacity: ${Math.min(t * 3, 1)};`,
   };
 </script>
 
-<div class="m3-container" class:has-js={hasJs} class:disabled class:error use:clickOutside>
+<div
+    class="m3-container"
+    class:has-js={hasJs}
+    class:disabled
+    class:error
+    use:clickOutside
+    style:--anchor-name={`--${id}`}
+>
   <input
     type="date"
     class="focus-none m3-font-body-large"
@@ -76,7 +83,10 @@ opacity: ${Math.min(t * 3, 1)};`,
     <Icon icon={iconCalendar} width="1.5rem" height="1.5rem" />
   </button>
   {#if picker}
-    <div class="picker" transition:enterExit>
+    <div
+        class="picker"
+        transition:enterExit
+    >
       <DatePickerDocked
         date={value}
         clearable={!required}
@@ -88,11 +98,24 @@ opacity: ${Math.min(t * 3, 1)};`,
 </div>
 
 <style>
+    :global {
+        @position-try --picker-bottom {
+          position-area: bottom;
+          margin-top: 1rem;
+        }
+        @position-try --picker-top {
+          position-area: top;
+          margin-bottom: 1rem;
+        }
+    }
+
+
   :root {
     --m3-datefield-shape: var(--m3-util-rounding-extra-small);
   }
   .m3-container {
     position: relative;
+    anchor-name: var(--anchor-name);
     height: calc(3.5rem + var(--m3-util-density-term));
     min-width: 15rem;
     background-color: rgb(var(--m3-scheme-surface-container-highest));
@@ -164,10 +187,13 @@ opacity: ${Math.min(t * 3, 1)};`,
   }
 
   .picker {
-    position: absolute;
-    top: calc(100% + 1rem);
-    right: 0;
-    z-index: 1;
+    position: fixed;
+    position-anchor: var(--anchor-name);
+    position-area: bottom;
+    margin-top: 1rem;
+    position-try-fallbacks:
+        --picker-bottom, --picker-top;
+      z-index: 1;
   }
 
   @media (min-width: 37.5rem) {

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -186,15 +186,27 @@ opacity: ${Math.min(t * 3, 1)};`,
     --error: var(--m3-scheme-error);
   }
 
-  .picker {
-    position: fixed;
-    position-anchor: var(--anchor-name);
-    position-area: bottom;
-    margin-top: 1rem;
-    position-try-fallbacks:
-        --picker-bottom, --picker-top;
-      z-index: 1;
-  }
+    @supports not (anchor-name: --a) {
+        .picker {
+            position: absolute;
+            top: calc(100% + 1rem);
+            right: 0;
+            z-index: 1;
+        }
+    }
+
+    @supports (anchor-name: --a) {
+        .picker {
+            position: fixed;
+            position-anchor: var(--anchor-name);
+            position-area: bottom;
+            margin-top: 1rem;
+            position-try-fallbacks:
+                --picker-bottom, --picker-top, bottom right, bottom left, top right, top left;
+            z-index: 1;
+            translate: 15% 0;
+        }
+    }
 
   @media (min-width: 37.5rem) {
     .has-js button {

--- a/src/lib/forms/DateField.svelte
+++ b/src/lib/forms/DateField.svelte
@@ -109,7 +109,7 @@ opacity: ${Math.min(t * 3, 1)};`,
         }
         @position-try --picker-bottom-left {
             position-area: bottom left;
-            margin-bottom: 1rem;
+            margin-top: 1rem;
         }
         @position-try --picker-top-left {
             position-area: top left;


### PR DESCRIPTION
I reviewed the [Anchor Positioning API](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning) that we discussed [here](https://github.com/KTibow/m3-svelte/issues/186) and came to the following conclusion:

The Anchor Positioning API doesn’t solve my issue; it only positions one element relative to another (correct me if I misunderstood the tool). Moreover, it currently requires Google Chrome Canary. I tested it in Google Chrome version 139.0.7258.155 and Firefox 142, and it did not work in either. I was only able to use the API in Chrome Canary after enabling the experimental flag at `chrome://flags#enable-experimental-web-platform-features`.

The problem I want to address is different: if the `DateField.svelte` component is located below the middle of the viewport, opening the picker causes it to extend beyond the viewport. The same issue can be observed on the [documentation page](https://ktibow.github.io/m3-svelte/) in the "Split button" section.

To illustrate a possible solution, I implemented logic in `DateField.svelte` that handles this case and keeps the picker within the viewport. I’d appreciate @KTibow’s feedback. Perhaps, after some discussion, this logic could be adapted (probably not in exactly the same form) and applied to other components, such as `SplitButton.svelte`.
