### PR TITLE
Wrapping & alignment fixes for FAB and NavigationRailItem labels

### DIFF
--- a/src/lib/buttons/FAB.svelte
+++ b/src/lib/buttons/FAB.svelte
@@ -74,6 +74,9 @@
     justify-content: center;
     cursor: pointer;
   }
+  span {
+    white-space: nowrap;
+  }
 
   .elevation-normal {
     box-shadow: var(--m3-elevation-3);

--- a/src/lib/buttons/FAB.svelte
+++ b/src/lib/buttons/FAB.svelte
@@ -73,8 +73,6 @@
     align-items: center;
     justify-content: center;
     cursor: pointer;
-  }
-  span {
     white-space: nowrap;
   }
 

--- a/src/lib/nav/NavigationRailItem.svelte
+++ b/src/lib/nav/NavigationRailItem.svelte
@@ -45,6 +45,13 @@
     border: none;
     cursor: pointer;
     animation: none !important;
+
+    > span {
+      text-align: center;
+    }
+    > span:first-of-type {
+      word-wrap: nowrap;
+    }
   }
 
   .m3-container {

--- a/src/lib/nav/NavigationRailItem.svelte
+++ b/src/lib/nav/NavigationRailItem.svelte
@@ -48,7 +48,7 @@
     text-align: center;
 
     > span:first-of-type {
-      word-wrap: nowrap;
+      white-space: nowrap;
     }
   }
 

--- a/src/lib/nav/NavigationRailItem.svelte
+++ b/src/lib/nav/NavigationRailItem.svelte
@@ -45,10 +45,8 @@
     border: none;
     cursor: pointer;
     animation: none !important;
+    text-align: center;
 
-    > span {
-      text-align: center;
-    }
     > span:first-of-type {
       word-wrap: nowrap;
     }


### PR DESCRIPTION
Introduces fixes for scenarios in which text labels for elements would wrap mid-animation when used in a \<NavigationRail>, and correctly centers \<a> NavigationRailItem labels.
Changes \<NavigationRailItem> labels to not wrap when expanded, which is not a strict requirement of Material Expressive. No official material takes a stance on the expanded state, so alternatively it'd be possible to use `white-space: pre;` to allow manual wrapping with `\n`. 


|Before|After|
|-------|-------|
|<video src="https://github.com/user-attachments/assets/e083e9d3-04b1-4d61-93c6-55851b1dfd6b">|<video src="https://github.com/user-attachments/assets/0a5a16aa-9dfc-43cc-93f9-5f7652774a16">|

(Animation speed slowed to 0.25x)


