### PR TITLE
Add TimePickerDial component

### DIFF
--- a/src/demos.md
+++ b/src/demos.md
@@ -1141,6 +1141,47 @@ let errored = $state(false);
 {/snippet}
 ```
 
+## Time picker
+
+Minimal demo:
+
+```svelte
+<TimePickerDial {time} setTime={(t) => (time = t)} close={() => (open = false)} />
+```
+
+Full demo:
+
+```use
+TimePickerDial
+Button
+```
+
+```ts
+let time = $state("09:30");
+let open = $state(false);
+```
+
+```svelte
+<Button variant="tonal" onclick={() => (open = true)}>
+  {time ? `Time: ${time}` : "Pick a time"}
+</Button>
+
+{#snippet demo()}
+  {#if open}
+    <div
+      style:position="fixed"
+      style:inset="0"
+      style:display="grid"
+      style:place-items="center"
+      style:background-color="rgb(0 0 0 / 0.5)"
+      style:z-index="10"
+    >
+      <TimePickerDial {time} clearable setTime={(t) => (time = t)} close={() => (open = false)} />
+    </div>
+  {/if}
+{/snippet}
+```
+
 ## Tabs
 
 Minimal demo:

--- a/src/demos.md
+++ b/src/demos.md
@@ -1146,7 +1146,9 @@ let errored = $state(false);
 Minimal demo:
 
 ```svelte
-<TimePickerDial {time} setTime={(t) => (time = t)} close={() => (open = false)} />
+{#if open}
+  <TimePickerDial {time} setTime={(t) => (time = t)} close={() => (open = false)} />
+{/if}
 ```
 
 Full demo:
@@ -1168,16 +1170,12 @@ let open = $state(false);
 
 {#snippet demo()}
   {#if open}
-    <div
-      style:position="fixed"
-      style:inset="0"
-      style:display="grid"
-      style:place-items="center"
-      style:background-color="rgb(0 0 0 / 0.5)"
-      style:z-index="10"
-    >
-      <TimePickerDial {time} clearable setTime={(t) => (time = t)} close={() => (open = false)} />
-    </div>
+    <TimePickerDial
+      {time}
+      clearable
+      setTime={(t) => (time = t)}
+      close={() => (open = false)}
+    />
   {/if}
 {/snippet}
 ```

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -1,0 +1,430 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import Button from "$lib/buttons/Button.svelte";
+
+  let {
+    time = "",
+    clearable = false,
+    close,
+    setTime,
+  }: {
+    time?: string;
+    clearable?: boolean;
+    close: () => void;
+    setTime: (time: string) => void;
+  } = $props();
+
+  // 24-hour "HH:MM" → integers. Empty string parses to 00:00.
+  const parseTime = (s: string): { h: number; m: number } => {
+    if (!s) return { h: 0, m: 0 };
+    const [hs, ms] = s.split(":");
+    return {
+      h: Math.max(0, Math.min(23, parseInt(hs) || 0)),
+      m: Math.max(0, Math.min(59, parseInt(ms) || 0)),
+    };
+  };
+  const fmt = (h: number, m: number) =>
+    `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+
+  const initial = parseTime(time);
+  let editH = $state(initial.h); // 0..23
+  let editM = $state(initial.m); // 0..59
+  let mode = $state<"hour" | "minute">("hour");
+
+  let isPm = $derived(editH >= 12);
+  let h12 = $derived(((editH + 11) % 12) + 1);
+
+  // --- Dial geometry ---
+  const DIAL = 256;
+  const CENTER = DIAL / 2;
+  const RADIUS = 100;
+  const NUM = 40;
+
+  // Continuous angle the arm + masked-glyph layer rotate to. In hour mode the
+  // value snaps to 30° per hour; in minute mode it's 6° per minute so the user
+  // can scrub through any value 0..59 by dragging between labelled positions.
+  //
+  // Animating an angle from e.g. 350° → 10° naively takes the long way around;
+  // we unwrap the angle here so the visual always moves the short arc.
+  let targetAngle = $derived(mode == "hour" ? (h12 == 12 ? 0 : h12) * 30 - 90 : editM * 6 - 90);
+  let visualAngle = $state(targetAngle);
+  $effect(() => {
+    let next = targetAngle;
+    while (next - visualAngle > 180) next -= 360;
+    while (next - visualAngle < -180) next += 360;
+    visualAngle = next;
+  });
+
+  const slotPos = (i: number) => {
+    const rad = ((i * 30 - 90) * Math.PI) / 180;
+    return { x: CENTER + RADIUS * Math.cos(rad), y: CENTER + RADIUS * Math.sin(rad) };
+  };
+  const slotLabel = (i: number) =>
+    mode == "hour" ? (i == 0 ? 12 : i).toString() : (i * 5).toString().padStart(2, "0");
+
+  // Unique mask id so multiple instances on a page don't collide.
+  const maskId = $props.id();
+
+  const applyHourSlot = (slot: number) => {
+    const i = ((slot % 12) + 12) % 12;
+    const h = i == 0 ? 12 : i;
+    const base = h == 12 ? 0 : h;
+    editH = base + (isPm ? 12 : 0);
+  };
+  const applyMinuteValue = (m: number) => {
+    editM = ((m % 60) + 60) % 60;
+  };
+
+  // Tapping an hour label advances to minute mode.
+  const pickHour = (slot: number) => {
+    applyHourSlot(slot);
+    mode = "minute";
+  };
+  // Tapping a minute label confirms.
+  const pickMinute = (m: number) => {
+    applyMinuteValue(m);
+    confirm();
+  };
+  const setAmPm = (toPm: boolean) => {
+    if (toPm == isPm) return;
+    editH = toPm ? editH + 12 : editH - 12;
+  };
+  const confirm = () => {
+    setTime(fmt(editH, editM));
+    close();
+  };
+  const cancel = () => close();
+  const clear = () => {
+    setTime("");
+    close();
+  };
+
+  // Pointer interaction. The initial tap snaps the needle with no transition;
+  // once movement crosses a small threshold the rest of the gesture is treated
+  // as a drag and the transition is re-enabled, so the needle glides after the
+  // cursor instead of teleporting on every pointermove event.
+  let dragging = false;
+  let movedPastThreshold = false;
+  let pointerStartX = 0;
+  let pointerStartY = 0;
+  let instantJump = $state(false);
+  const DRAG_THRESHOLD = 4; // px
+
+  const updateFromPointer = (e: PointerEvent) => {
+    const dial = e.currentTarget as HTMLElement;
+    const r = dial.getBoundingClientRect();
+    const dx = e.clientX - r.left - r.width / 2;
+    const dy = e.clientY - r.top - r.height / 2;
+    const ang = (Math.atan2(dy, dx) * 180) / Math.PI; // -180..180, 0 = right
+    const norm = (((ang + 90) % 360) + 360) % 360; // 0..360, 0 = top
+    if (mode == "hour") applyHourSlot(Math.round(norm / 30) % 12);
+    else applyMinuteValue(Math.round(norm / 6));
+  };
+  const onDialPointerDown = (e: PointerEvent) => {
+    if (e.button != 0) return;
+    dragging = true;
+    movedPastThreshold = false;
+    instantJump = true;
+    pointerStartX = e.clientX;
+    pointerStartY = e.clientY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    updateFromPointer(e);
+  };
+  const onDialPointerMove = (e: PointerEvent) => {
+    if (!dragging) return;
+    if (!movedPastThreshold) {
+      const dx = e.clientX - pointerStartX;
+      const dy = e.clientY - pointerStartY;
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+      movedPastThreshold = true;
+      instantJump = false;
+    }
+    updateFromPointer(e);
+  };
+  const onDialPointerUp = async (e: PointerEvent) => {
+    if (!dragging) return;
+    dragging = false;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      /* no-op */
+    }
+    // Let the no-transition snap render before we re-enable transitions and
+    // trigger the autonomous follow-up (hour → minute, or confirm on minute).
+    await tick();
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    instantJump = false;
+    if (mode == "hour") mode = "minute";
+    else confirm();
+  };
+</script>
+
+<div class="m3-container">
+  <p class="title">Select time</p>
+
+  <div class="display">
+    <button
+      type="button"
+      class="seg"
+      class:on={mode == "hour"}
+      onclick={() => (mode = "hour")}
+      aria-label="Select hour"
+    >
+      {h12.toString().padStart(2, "0")}
+    </button>
+    <span class="colon">:</span>
+    <button
+      type="button"
+      class="seg"
+      class:on={mode == "minute"}
+      onclick={() => (mode = "minute")}
+      aria-label="Select minute"
+    >
+      {editM.toString().padStart(2, "0")}
+    </button>
+    <div class="ampm">
+      <button type="button" class:on={!isPm} onclick={() => setAmPm(false)}>AM</button>
+      <button type="button" class:on={isPm} onclick={() => setAmPm(true)}>PM</button>
+    </div>
+  </div>
+
+  <svg
+    class="dial"
+    class:no-anim={instantJump}
+    width={DIAL}
+    height={DIAL}
+    viewBox="0 0 {DIAL} {DIAL}"
+    onpointerdown={onDialPointerDown}
+    onpointermove={onDialPointerMove}
+    onpointerup={onDialPointerUp}
+    onpointercancel={onDialPointerUp}
+  >
+    <!-- Dial face -->
+    <circle cx={CENTER} cy={CENTER} r={CENTER} fill="var(--m3c-surface-container-highest)" />
+
+    <!-- The mask cuts a circular window over the rotating disc, so the colour-
+         inverted text layer only shows through where the disc currently sits.
+         Both this circle and the visible arm share the same --angle rotation. -->
+    <defs>
+      <mask id={maskId}>
+        <rect width={DIAL} height={DIAL} fill="black" />
+        <circle
+          cx={CENTER + RADIUS}
+          cy={CENTER}
+          r={NUM / 2}
+          fill="white"
+          class="rot"
+          style="--angle: {visualAngle}deg"
+        />
+      </mask>
+    </defs>
+
+    <!-- Centre dot -->
+    <circle cx={CENTER} cy={CENTER} r="4" fill="var(--m3c-primary)" />
+
+    <!-- Default numbers (base layer, always rendered). -->
+    {#each Array(12) as _, i (i)}
+      {@const p = slotPos(i)}
+      <text
+        x={p.x}
+        y={p.y}
+        class="num default"
+        text-anchor="middle"
+        dominant-baseline="central"
+        onclick={() => (mode == "hour" ? pickHour(i) : pickMinute(i * 5))}
+      >
+        {slotLabel(i)}
+      </text>
+    {/each}
+
+    <!-- The arm: line + disc, rotating around the dial centre. -->
+    <g class="rot" style="--angle: {visualAngle}deg" pointer-events="none">
+      <line x1={CENTER} y1={CENTER} x2={CENTER + RADIUS} y2={CENTER} class="hand" />
+      <circle cx={CENTER + RADIUS} cy={CENTER} r={NUM / 2} class="disc" />
+    </g>
+
+    <!-- Inverted-glyph layer: same numbers in on-primary, but only visible
+         through the rotating mask hole — so as the disc passes a number, that
+         portion of the glyph smoothly flips colour. -->
+    <g mask="url(#{maskId})" pointer-events="none">
+      {#each Array(12) as _, i (i)}
+        {@const p = slotPos(i)}
+        <text x={p.x} y={p.y} class="num inverted" text-anchor="middle" dominant-baseline="central">
+          {slotLabel(i)}
+        </text>
+      {/each}
+    </g>
+  </svg>
+
+  <div class="actions">
+    {#if clearable}
+      <span class="left">
+        <Button variant="text" onclick={clear} type="button">Clear</Button>
+      </span>
+    {/if}
+    <Button variant="text" onclick={cancel} type="button">Cancel</Button>
+    <Button variant="text" onclick={confirm} type="button">OK</Button>
+  </div>
+</div>
+
+<style>
+  @layer tokens {
+    :root {
+      --m3-time-picker-shape: var(--m3-shape-extra-large);
+    }
+  }
+
+  /* Register --angle as a real <angle> custom property so CSS can interpolate
+     it during a transition — without @property the value would just snap. */
+  @property --angle {
+    syntax: "<angle>";
+    initial-value: 0deg;
+    inherits: false;
+  }
+
+  .m3-container {
+    display: flex;
+    flex-direction: column;
+    width: 20.5rem;
+    padding: 1.5rem 1.5rem 0.25rem;
+    gap: 1.25rem;
+    background-color: var(--m3c-surface-container-high);
+    color: var(--m3c-on-surface);
+    border-radius: var(--m3-time-picker-shape);
+  }
+
+  .title {
+    @apply --m3-label-medium;
+    margin: 0;
+    color: var(--m3c-on-surface-variant);
+  }
+
+  /* HH:MM display + AM/PM toggle ----------------------------------------- */
+  .display {
+    display: flex;
+    align-items: stretch;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+  .seg {
+    @apply --m3-display-medium;
+    flex: none;
+    min-width: 5.5rem;
+    padding: 0.875rem 0.5rem;
+    text-align: center;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: var(--m3c-surface-container-highest);
+    color: var(--m3c-on-surface);
+    cursor: pointer;
+    transition:
+      background-color 140ms,
+      color 140ms;
+  }
+  /* Selected segment is the filled-tonal inversion: bright primary fill with
+     on-primary text (the same tonal pair Android M3 uses for the active
+     segment, so it reads as dark glyphs on a light fill). */
+  .seg.on {
+    background-color: var(--m3c-primary);
+    color: var(--m3c-on-primary);
+  }
+  .colon {
+    @apply --m3-display-medium;
+    display: flex;
+    align-items: center;
+    /* The ':' glyph sits low in its line-box — nudge it up so it visually
+       centres between the two digit segments. */
+    transform: translateY(-0.375rem);
+  }
+  /* AM/PM toggle: two pill buttons stacked vertically, not bordered as a
+     single container. `flex: none` so the parent flex row can't crush them. */
+  .ampm {
+    flex: none;
+    width: 3.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-left: 0.5rem;
+  }
+  .ampm button {
+    @apply --m3-label-large;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    /* Inactive = squarish outlined pill. */
+    border-radius: 0.5rem;
+    cursor: pointer;
+    color: var(--m3c-on-surface-variant);
+    background-color: transparent;
+    box-shadow: inset 0 0 0 1px var(--m3c-outline);
+    transition:
+      background-color 140ms,
+      color 140ms,
+      box-shadow 140ms,
+      border-radius 140ms;
+  }
+  /* Active = tonal pink fill, fully rounded — the M3 "shape morph" between
+     the rectangular inactive state and the pill active state. */
+  .ampm button.on {
+    background-color: var(--m3c-tertiary-container);
+    color: var(--m3c-on-tertiary-container);
+    box-shadow: none;
+    border-radius: var(--m3-shape-full);
+  }
+
+  /* Dial ----------------------------------------------------------------- */
+  .dial {
+    display: block;
+    margin: 0.5rem auto 0;
+    touch-action: none;
+    user-select: none;
+  }
+  /* The arm + the mask disc share this rule, so they orbit in lock-step
+     around the dial centre via the same interpolated --angle. */
+  .rot {
+    --angle: 0deg;
+    transform-origin: 50% 50%;
+    transform: rotate(var(--angle));
+    transition: --angle 220ms cubic-bezier(0.2, 0, 0, 1);
+  }
+  /* While the pointer is on the dial, freeze the transition so every click
+     snaps the needle 1:1 to the cursor. Once the user releases, the class is
+     removed and the autonomous mode-swap (or confirm) transition glides. */
+  .dial.no-anim .rot {
+    transition: none;
+  }
+  .hand {
+    stroke: var(--m3c-primary);
+    stroke-width: 2;
+    stroke-linecap: round;
+  }
+  .disc {
+    fill: var(--m3c-primary);
+  }
+  .num {
+    @apply --m3-body-large;
+    font-family: inherit;
+  }
+  .num.default {
+    fill: var(--m3c-on-surface);
+    cursor: pointer;
+  }
+  .num.inverted {
+    fill: var(--m3c-on-primary);
+    pointer-events: none;
+  }
+
+  /* Actions -------------------------------------------------------------- */
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+  }
+  .actions > .left {
+    margin-right: auto;
+  }
+</style>

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -32,9 +32,7 @@
   let mode = $state<"hour" | "minute">("hour");
 
   let isPm = $derived(editH >= 12);
-  let h12 = $derived(((editH + 11) % 12) + 1);
-  const initialH12 = ((initial.h + 11) % 12) + 1;
-
+  let h12 = $derived((editH % 12) || 12);
   // --- Dial geometry ---
   const DIAL = 256;
   const CENTER = DIAL / 2;
@@ -46,14 +44,13 @@
   // can scrub through any value 0..59 by dragging between labelled positions.
   // The spring drives the actual rendered angle so this stays snappy without
   // relying on CSS interpolation of custom properties.
-  const visualAngle = new Spring((initialH12 == 12 ? 0 : initialH12) * 30 - 90, {
+  const visualAngle = new Spring((initial.h % 12) * 30 - 90, {
     stiffness: 0.3,
     damping: 1,
   });
   $effect(() => {
-    let next = mode == "hour" ? (h12 == 12 ? 0 : h12) * 30 - 90 : editM * 6 - 90;
-    while (next - visualAngle.target > 180) next -= 360;
-    while (next - visualAngle.target < -180) next += 360;
+    let next = mode == "hour" ? (editH % 12) * 30 - 90 : editM * 6 - 90;
+    next -= Math.round((next - visualAngle.target) / 360) * 360;
     if (instantJump) void visualAngle.set(next, { instant: true });
     else visualAngle.target = next;
   });
@@ -63,19 +60,16 @@
     return { x: CENTER + RADIUS * Math.cos(rad), y: CENTER + RADIUS * Math.sin(rad) };
   };
   const slotLabel = (i: number) =>
-    mode == "hour" ? (i == 0 ? 12 : i).toString() : (i * 5).toString().padStart(2, "0");
+    mode == "hour" ? (i || 12).toString() : (i * 5).toString().padStart(2, "0");
 
   // Unique mask id so multiple instances on a page don't collide.
   const maskId = $props.id();
 
   const applyHourSlot = (slot: number) => {
-    const i = ((slot % 12) + 12) % 12;
-    const h = i == 0 ? 12 : i;
-    const base = h == 12 ? 0 : h;
-    editH = base + (isPm ? 12 : 0);
+    editH = (slot % 12) + (isPm ? 12 : 0);
   };
   const applyMinuteValue = (m: number) => {
-    editM = ((m % 60) + 60) % 60;
+    editM = m % 60;
   };
 
   // Tapping an hour label advances to minute mode.
@@ -119,7 +113,7 @@
     const dy = e.clientY - r.top - r.height / 2;
     const ang = (Math.atan2(dy, dx) * 180) / Math.PI; // -180..180, 0 = right
     const norm = (((ang + 90) % 360) + 360) % 360; // 0..360, 0 = top
-    if (mode == "hour") applyHourSlot(Math.round(norm / 30) % 12);
+    if (mode == "hour") applyHourSlot(Math.round(norm / 30));
     else applyMinuteValue(Math.round(norm / 6));
   };
   const onDialPointerDown = (e: PointerEvent) => {

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -5,7 +5,7 @@
   let {
     time = "",
     clearable = false,
-    close,
+    close: closeProp,
     setTime,
   }: {
     time?: string;
@@ -72,28 +72,25 @@
     editM = m % 60;
   };
 
-  // Tapping an hour label advances to minute mode.
-  const pickHour = (slot: number) => {
-    applyHourSlot(slot);
-    mode = "minute";
-  };
-  // Tapping a minute label confirms.
-  const pickMinute = (m: number) => {
-    applyMinuteValue(m);
-    confirm();
-  };
   const setAmPm = (toPm: boolean) => {
     if (toPm == isPm) return;
     editH = toPm ? editH + 12 : editH - 12;
   };
+  // --- Dialog lifecycle ---
+  let dialog: HTMLDialogElement | undefined = $state();
+  $effect(() => {
+    if (!dialog) return;
+    dialog.showModal();
+  });
+
   const confirm = () => {
     setTime(fmt(editH, editM));
-    close();
+    dialog?.close();
   };
-  const cancel = () => close();
+  const cancel = () => dialog?.close();
   const clear = () => {
     setTime("");
-    close();
+    dialog?.close();
   };
 
   // Pointer interaction. The initial tap snaps the needle immediately; once
@@ -151,7 +148,7 @@
   };
 </script>
 
-<div class="m3-container">
+<dialog class="m3-container" bind:this={dialog} closedby="any" onclose={closeProp}>
   <p class="title">Select time</p>
 
   <div class="display">
@@ -250,7 +247,7 @@
     <Button variant="text" onclick={cancel} type="button">Cancel</Button>
     <Button variant="text" onclick={confirm} type="button">OK</Button>
   </div>
-</div>
+</dialog>
 
 <style>
   @layer tokens {
@@ -268,6 +265,21 @@
     background-color: var(--m3c-surface-container-high);
     color: var(--m3c-on-surface);
     border-radius: var(--m3-time-picker-shape);
+    border: none;
+    inset: 0;
+    margin: auto;
+  }
+  .m3-container::backdrop {
+    background-color: --translucent(var(--m3c-scrim), 0.3);
+    animation: fadeIn 150ms;
+  }
+  @keyframes fadeIn {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
   }
 
   .title {

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -37,7 +37,7 @@
   const DIAL = 256;
   const CENTER = DIAL / 2;
   const RADIUS = 100;
-  const NUM = 40;
+  const NUM = 48;
 
   // Continuous angle the arm + masked-glyph layer rotate to. In hour mode the
   // value snaps to 30° per hour; in minute mode it's 6° per minute so the user
@@ -284,7 +284,7 @@
     justify-content: center;
   }
   .seg {
-    @apply --m3-display-medium;
+    @apply --m3-display-large;
     flex: none;
     min-width: 5.5rem;
     padding: 0.875rem 0.5rem;
@@ -298,15 +298,14 @@
       background-color 140ms,
       color 140ms;
   }
-  /* Selected segment is the filled-tonal inversion: bright primary fill with
-     on-primary text (the same tonal pair Android M3 uses for the active
-     segment, so it reads as dark glyphs on a light fill). */
+  /* Selected segment uses the primary-container / on-primary-container pair,
+     which M3 uses for the active time segment. */
   .seg.on {
-    background-color: var(--m3c-primary);
-    color: var(--m3c-on-primary);
+    background-color: var(--m3c-primary-container);
+    color: var(--m3c-on-primary-container);
   }
   .colon {
-    @apply --m3-display-medium;
+    @apply --m3-display-large;
     display: flex;
     align-items: center;
     /* The ':' glyph sits low in its line-box — nudge it up so it visually
@@ -317,14 +316,14 @@
      single container. `flex: none` so the parent flex row can't crush them. */
   .ampm {
     flex: none;
-    width: 3.75rem;
+    width: 3.25rem;
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
     margin-left: 0.5rem;
   }
   .ampm button {
-    @apply --m3-label-large;
+    @apply --m3-title-medium;
     flex: 1;
     display: flex;
     align-items: center;

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -282,12 +282,16 @@
     align-items: stretch;
     gap: 0.5rem;
     justify-content: center;
+    height: 5rem;
   }
   .seg {
     @apply --m3-display-large;
     flex: none;
     min-width: 5.5rem;
-    padding: 0.875rem 0.5rem;
+    padding-inline: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     border: none;
     border-radius: 0.5rem;
@@ -321,6 +325,7 @@
     flex-direction: column;
     gap: 0.25rem;
     margin-left: 0.5rem;
+    height: 5rem;
   }
   .ampm button {
     @apply --m3-title-medium;
@@ -348,7 +353,7 @@
     background-color: var(--m3c-tertiary-container);
     color: var(--m3c-on-tertiary-container);
     box-shadow: none;
-    border-radius: var(--m3-shape-full);
+    border-radius: 1.1875rem;
   }
 
   /* Dial ----------------------------------------------------------------- */

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -103,8 +103,8 @@
   let instantJump = $state(false);
   const DRAG_THRESHOLD = 4; // px
 
-  const updateFromPointer = (e: PointerEvent) => {
-    const dial = e.currentTarget as HTMLElement;
+  const updateFromPointer = (e: PointerEvent & { currentTarget: Element }) => {
+    const dial = e.currentTarget;
     const r = dial.getBoundingClientRect();
     const dx = e.clientX - r.left - r.width / 2;
     const dy = e.clientY - r.top - r.height / 2;
@@ -113,17 +113,17 @@
     if (mode == "hour") applyHourSlot(Math.round(norm / 30));
     else applyMinuteValue(Math.round(norm / 6));
   };
-  const onDialPointerDown = (e: PointerEvent) => {
+  const onDialPointerDown = (e: PointerEvent & { currentTarget: Element }) => {
     if (e.button != 0) return;
     dragging = true;
     movedPastThreshold = false;
     instantJump = true;
     pointerStartX = e.clientX;
     pointerStartY = e.clientY;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    e.currentTarget.setPointerCapture(e.pointerId);
     updateFromPointer(e);
   };
-  const onDialPointerMove = (e: PointerEvent) => {
+  const onDialPointerMove = (e: PointerEvent & { currentTarget: Element }) => {
     if (!dragging) return;
     if (!movedPastThreshold) {
       const dx = e.clientX - pointerStartX;
@@ -134,11 +134,11 @@
     }
     updateFromPointer(e);
   };
-  const onDialPointerUp = (e: PointerEvent) => {
+  const onDialPointerUp = (e: PointerEvent & { currentTarget: Element }) => {
     if (!dragging) return;
     dragging = false;
     try {
-      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+      e.currentTarget.releasePointerCapture(e.pointerId);
     } catch {
       /* no-op */
     }

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { tick } from "svelte";
   import Button from "$lib/buttons/Button.svelte";
+  import { Spring } from "svelte/motion";
 
   let {
     time = "",
@@ -33,6 +33,7 @@
 
   let isPm = $derived(editH >= 12);
   let h12 = $derived(((editH + 11) % 12) + 1);
+  const initialH12 = ((initial.h + 11) % 12) + 1;
 
   // --- Dial geometry ---
   const DIAL = 256;
@@ -43,16 +44,18 @@
   // Continuous angle the arm + masked-glyph layer rotate to. In hour mode the
   // value snaps to 30° per hour; in minute mode it's 6° per minute so the user
   // can scrub through any value 0..59 by dragging between labelled positions.
-  //
-  // Animating an angle from e.g. 350° → 10° naively takes the long way around;
-  // we unwrap the angle here so the visual always moves the short arc.
-  let targetAngle = $derived(mode == "hour" ? (h12 == 12 ? 0 : h12) * 30 - 90 : editM * 6 - 90);
-  let visualAngle = $state(targetAngle);
+  // The spring drives the actual rendered angle so this stays snappy without
+  // relying on CSS interpolation of custom properties.
+  const visualAngle = new Spring((initialH12 == 12 ? 0 : initialH12) * 30 - 90, {
+    stiffness: 0.3,
+    damping: 1,
+  });
   $effect(() => {
-    let next = targetAngle;
-    while (next - visualAngle > 180) next -= 360;
-    while (next - visualAngle < -180) next += 360;
-    visualAngle = next;
+    let next = mode == "hour" ? (h12 == 12 ? 0 : h12) * 30 - 90 : editM * 6 - 90;
+    while (next - visualAngle.target > 180) next -= 360;
+    while (next - visualAngle.target < -180) next += 360;
+    if (instantJump) void visualAngle.set(next, { instant: true });
+    else visualAngle.target = next;
   });
 
   const slotPos = (i: number) => {
@@ -99,10 +102,9 @@
     close();
   };
 
-  // Pointer interaction. The initial tap snaps the needle with no transition;
-  // once movement crosses a small threshold the rest of the gesture is treated
-  // as a drag and the transition is re-enabled, so the needle glides after the
-  // cursor instead of teleporting on every pointermove event.
+  // Pointer interaction. The initial tap snaps the needle immediately; once
+  // movement crosses a small threshold the rest of the gesture is treated as a
+  // drag and the spring follows the cursor instead of teleporting every event.
   let dragging = false;
   let movedPastThreshold = false;
   let pointerStartX = 0;
@@ -141,7 +143,7 @@
     }
     updateFromPointer(e);
   };
-  const onDialPointerUp = async (e: PointerEvent) => {
+  const onDialPointerUp = (e: PointerEvent) => {
     if (!dragging) return;
     dragging = false;
     try {
@@ -149,10 +151,6 @@
     } catch {
       /* no-op */
     }
-    // Let the no-transition snap render before we re-enable transitions and
-    // trigger the autonomous follow-up (hour → minute, or confirm on minute).
-    await tick();
-    await new Promise<void>((r) => requestAnimationFrame(() => r()));
     instantJump = false;
     if (mode == "hour") mode = "minute";
     else confirm();
@@ -190,7 +188,6 @@
 
   <svg
     class="dial"
-    class:no-anim={instantJump}
     width={DIAL}
     height={DIAL}
     viewBox="0 0 {DIAL} {DIAL}"
@@ -204,7 +201,7 @@
 
     <!-- The mask cuts a circular window over the rotating disc, so the colour-
          inverted text layer only shows through where the disc currently sits.
-         Both this circle and the visible arm share the same --angle rotation. -->
+         Both this circle and the visible arm share the same spring rotation. -->
     <defs>
       <mask id={maskId}>
         <rect width={DIAL} height={DIAL} fill="black" />
@@ -214,7 +211,7 @@
           r={NUM / 2}
           fill="white"
           class="rot"
-          style="--angle: {visualAngle}deg"
+          style="transform: rotate({visualAngle.current}deg)"
         />
       </mask>
     </defs>
@@ -238,7 +235,7 @@
     {/each}
 
     <!-- The arm: line + disc, rotating around the dial centre. -->
-    <g class="rot" style="--angle: {visualAngle}deg" pointer-events="none">
+    <g class="rot" style="transform: rotate({visualAngle.current}deg)" pointer-events="none">
       <line x1={CENTER} y1={CENTER} x2={CENTER + RADIUS} y2={CENTER} class="hand" />
       <circle cx={CENTER + RADIUS} cy={CENTER} r={NUM / 2} class="disc" />
     </g>
@@ -272,14 +269,6 @@
     :root {
       --m3-time-picker-shape: var(--m3-shape-extra-large);
     }
-  }
-
-  /* Register --angle as a real <angle> custom property so CSS can interpolate
-     it during a transition — without @property the value would just snap. */
-  @property --angle {
-    syntax: "<angle>";
-    initial-value: 0deg;
-    inherits: false;
   }
 
   .m3-container {
@@ -383,18 +372,9 @@
     user-select: none;
   }
   /* The arm + the mask disc share this rule, so they orbit in lock-step
-     around the dial centre via the same interpolated --angle. */
+     around the dial centre via the same spring-driven angle. */
   .rot {
-    --angle: 0deg;
     transform-origin: 50% 50%;
-    transform: rotate(var(--angle));
-    transition: --angle 220ms cubic-bezier(0.2, 0, 0, 1);
-  }
-  /* While the pointer is on the dial, freeze the transition so every click
-     snaps the needle 1:1 to the cursor. Once the user releases, the class is
-     removed and the autonomous mode-swap (or confirm) transition glides. */
-  .dial.no-anim .rot {
-    transition: none;
   }
   .hand {
     stroke: var(--m3c-primary);

--- a/src/lib/forms/TimePickerDial.svelte
+++ b/src/lib/forms/TimePickerDial.svelte
@@ -32,7 +32,7 @@
   let mode = $state<"hour" | "minute">("hour");
 
   let isPm = $derived(editH >= 12);
-  let h12 = $derived((editH % 12) || 12);
+  let h12 = $derived(editH % 12 || 12);
   // --- Dial geometry ---
   const DIAL = 256;
   const CENTER = DIAL / 2;
@@ -180,6 +180,7 @@
     </div>
   </div>
 
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <svg
     class="dial"
     width={DIAL}
@@ -216,14 +217,7 @@
     <!-- Default numbers (base layer, always rendered). -->
     {#each Array(12) as _, i (i)}
       {@const p = slotPos(i)}
-      <text
-        x={p.x}
-        y={p.y}
-        class="num default"
-        text-anchor="middle"
-        dominant-baseline="central"
-        onclick={() => (mode == "hour" ? pickHour(i) : pickMinute(i * 5))}
-      >
+      <text x={p.x} y={p.y} class="num default" text-anchor="middle" dominant-baseline="central">
         {slotLabel(i)}
       </text>
     {/each}
@@ -364,6 +358,7 @@
     margin: 0.5rem auto 0;
     touch-action: none;
     user-select: none;
+    cursor: pointer;
   }
   /* The arm + the mask disc share this rule, so they orbit in lock-step
      around the dial centre via the same spring-driven angle. */
@@ -384,7 +379,6 @@
   }
   .num.default {
     fill: var(--m3c-on-surface);
-    cursor: pointer;
   }
   .num.inverted {
     fill: var(--m3c-on-primary);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -42,6 +42,7 @@ export { default as TextField } from "./forms/TextField.svelte";
 export { default as TextFieldMultiline } from "./forms/TextFieldMultiline.svelte";
 export { default as TextFieldOutlined } from "./forms/TextFieldOutlined.svelte";
 export { default as TextFieldOutlinedMultiline } from "./forms/TextFieldOutlinedMultiline.svelte";
+export { default as TimePickerDial } from "./forms/TimePickerDial.svelte";
 export { default as WavyLinearProgress } from "./forms/WavyLinearProgress.svelte";
 export { default as WavyLinearProgressEstimate } from "./forms/WavyLinearProgressEstimate.svelte";
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,6 +33,7 @@
   import Demo23 from "virtual:demo/23";
   import Demo24 from "virtual:demo/24";
   import Demo25 from "virtual:demo/25";
+  import Demo26 from "virtual:demo/26";
   import { afterNavigate } from "$app/navigation";
 
   type DocData = {
@@ -103,7 +104,8 @@
     <Demo23 {showCode} />
     <Demo24 {showCode} />
     <Demo25 {showCode} />
-    {#await import("virtual:demo/26") then { default: LastDemo }}
+    <Demo26 {showCode} />
+    {#await import("virtual:demo/27") then { default: LastDemo }}
       <LastDemo {showCode} />
     {/await}
   </main>


### PR DESCRIPTION
## Summary

Adds a Material 3 **modal time picker — dial** to the forms catalog: `TimePickerDial`.

It mirrors the API shape of `DatePickerDocked`:

```ts
{
  time?: string;                // 24h "HH:MM" — same format <input type="time"> produces
  clearable?: boolean;          // shows a "Clear" action
  close: () => void;
  setTime: (time: string) => void;
}
```

Usage matches the docked-date-picker idiom — the consumer composes it into whatever shell they want (a Dialog, a sheet, an anchored popup, etc.):

```svelte
{#if open}
  <Dialog ...>
    <TimePickerDial {time} setTime={(t) => (time = t)} close={() => (open = false)} />
  </Dialog>
{/if}
```

## What it does

- Big HH:MM display with hour/minute segments; tapping a segment swaps the dial mode.
- AM/PM toggle as two pill buttons with the M3 inactive→active shape morph (squarish outline → full pill, tonal fill on the active one).
- 12-position clock dial. Hour mode snaps to 30° per hour; minute mode is per-minute (6°) so dragging through the gaps picks any value 0–59, matching the Android dial picker.
- Pointer interaction:
  - Initial tap snaps the needle (no transition).
  - Once the gesture passes a small movement threshold, the transition re-enables so the needle glides after the cursor instead of teleporting on every `pointermove`.
  - On release: hour mode → minute mode; minute mode → `setTime` + `close`.
- A masked inverted-glyph layer flips the numbers under the disc to `on-primary` smoothly as the disc moves over them, instead of swapping a `.selected` class.
- Angle is animated via a registered `--angle` `<angle>` custom property and unwrapped (±360°) so e.g. 11→1 hour travels the short arc.

## Conventions

- 2-space indent, `printWidth: 100`, formatter applied.
- `.m3-container` wrapper, `--m3c-*` tokens, `@apply --m3-*` type mixins, `--m3-shape-*` for radii.
- Adds `--m3-time-picker-shape` token under `@layer tokens` (defaults to `--m3-shape-extra-large`).
- Uses the existing `$lib/buttons/Button` for the Cancel / OK / Clear text buttons.
- Svelte 5 runes throughout; `$props.id()` for a unique SVG `mask` id.
- Exported from `src/lib/index.ts`.
- Demo added to `src/demos.md` next to the Date field demo; demo wiring in `src/routes/+page.svelte` bumped accordingly (Demo26 now static, lazy `LastDemo` becomes `virtual:demo/27`).

## Test plan

- [x] `pnpm install`
- [x] `pnpm check` → 0 errors (only the pre-existing `iconColorLens` warning and the project-wide `@apply` CSS warnings that exist on `main`)
- [x] `pnpm lint` → clean (same pre-existing warning)
- [x] `pnpm build` → succeeds; `virtual:demo/26` (Time picker) and `virtual:demo/27` (Shapes) generate correctly
- [x] `svelte-package` output ships `package/forms/TimePickerDial.svelte` and exports it from `package/index.{js,d.ts}`
- [x] Spin up `pnpm dev`, open the demo card, scrub the dial in both modes, confirm AM/PM toggle + Cancel/OK/Clear all behave